### PR TITLE
Add navigation between blog posts

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,13 @@ The `src/content/` directory contains "collections" of related Markdown and MDX 
 
 Any static assets, like images, can be placed in the `public/` directory.
 
+### Adding new articles
+
+To publish a blog post, copy the file `src/content/blog/_template.md.sample` and rename
+it to something like `your-title.md`. Fill in the front matter fields (use
+`YYYY-MM-DD` dates) and write your content in Markdown or MDX. Once committed,
+the article will appear on your site.
+
 ## 🧞 Commands
 
 All commands are run from the root of the project, from a terminal:

--- a/src/components/PostNavigation.astro
+++ b/src/components/PostNavigation.astro
@@ -1,0 +1,27 @@
+---
+interface NavProps {
+    prev?: { id: string; data: { title: string } };
+    next?: { id: string; data: { title: string } };
+}
+const { prev, next } = Astro.props as NavProps;
+---
+<nav class="post-nav">
+    {prev && (
+        <a href={`/blog/${prev.id}/`} class="prev">\u00ab {prev.data.title}</a>
+    )}
+    {next && (
+        <a href={`/blog/${next.id}/`} class="next">{next.data.title} \u00bb</a>
+    )}
+</nav>
+<style>
+.post-nav {
+    display: flex;
+    justify-content: space-between;
+    margin: 2em 0;
+    padding: 0 1em;
+}
+.post-nav a {
+    color: var(--accent);
+    text-decoration: none;
+}
+</style>

--- a/src/content/blog/_template.md.sample
+++ b/src/content/blog/_template.md.sample
@@ -1,0 +1,10 @@
+---
+title: "Title of Your Post"
+description: "Short description"
+pubDate: "yyyy-mm-dd"
+# Optional fields
+updatedDate: "yyyy-mm-dd"
+heroImage: "/path/to/image.jpg"
+---
+
+Write your article content here using Markdown or MDX.

--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -4,10 +4,15 @@ import BaseHead from '../components/BaseHead.astro';
 import Header from '../components/Header.astro';
 import Footer from '../components/Footer.astro';
 import FormattedDate from '../components/FormattedDate.astro';
+import PostNavigation from '../components/PostNavigation.astro';
 
-type Props = CollectionEntry<'blog'>['data'];
+type Props = CollectionEntry<'blog'>['data'] & {
+    prev?: { id: string; data: { title: string } };
+    next?: { id: string; data: { title: string } };
+};
 
-const { title, description, pubDate, updatedDate, heroImage } = Astro.props;
+const { title, description, pubDate, updatedDate, heroImage, prev, next } =
+    Astro.props as Props;
 ---
 
 <html lang="en">
@@ -76,10 +81,11 @@ const { title, description, pubDate, updatedDate, heroImage } = Astro.props;
 						<h1>{title}</h1>
 						<hr />
 					</div>
-					<slot />
-				</div>
-			</article>
-		</main>
+                                        <slot />
+                                        <PostNavigation prev={prev} next={next} />
+                                </div>
+                        </article>
+                </main>
 		<Footer />
 	</body>
 </html>

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -12,10 +12,16 @@ export async function getStaticPaths() {
 }
 type Props = CollectionEntry<'blog'>;
 
-const post = Astro.props;
+const post = Astro.props as Props;
 const { Content } = await render(post);
+const allPosts = (await getCollection('blog')).sort(
+    (a, b) => a.data.pubDate.valueOf() - b.data.pubDate.valueOf(),
+);
+const index = allPosts.findIndex((p) => p.id === post.id);
+const prev = index > 0 ? allPosts[index - 1] : undefined;
+const next = index < allPosts.length - 1 ? allPosts[index + 1] : undefined;
 ---
 
-<BlogPost {...post.data}>
-	<Content />
+<BlogPost {...post.data} prev={prev} next={next}>
+        <Content />
 </BlogPost>


### PR DESCRIPTION
## Summary
- create `PostNavigation` component
- pass next and previous posts to the blog post layout
- render navigation links on each blog post

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68629bac6a8c832ca4a53c4511c01f5f