### PR TITLE
Add sidebar module with top and recent posts

### DIFF
--- a/src/components/Sidebar.astro
+++ b/src/components/Sidebar.astro
@@ -1,0 +1,78 @@
+---
+import { getCollection } from 'astro:content';
+import FormattedDate from './FormattedDate.astro';
+
+const posts = await getCollection('blog');
+
+const mostViewed = [...posts]
+  .sort((a, b) => (b.data.views ?? 0) - (a.data.views ?? 0))
+  .slice(0, 5);
+const mostLiked = [...posts]
+  .sort((a, b) => (b.data.likes ?? 0) - (a.data.likes ?? 0))
+  .slice(0, 3);
+const newest = [...posts]
+  .sort((a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf())
+  .slice(0, 3);
+---
+
+<aside class="sidebar">
+  <section>
+    <h3>Top 5 wyświetleń</h3>
+    <ul>
+      {mostViewed.map((post) => (
+        <li>
+          <a href={`/blog/${post.id}/`}>{post.data.title}</a>
+          <span class="count">{post.data.views}</span>
+        </li>
+      ))}
+    </ul>
+  </section>
+  <section>
+    <h3>Najwięcej polubień</h3>
+    <ul>
+      {mostLiked.map((post) => (
+        <li>
+          <a href={`/blog/${post.id}/`}>{post.data.title}</a>
+          <span class="count">{post.data.likes}</span>
+        </li>
+      ))}
+    </ul>
+  </section>
+  <section>
+    <h3>Najnowsze artykuły</h3>
+    <ul>
+      {newest.map((post) => (
+        <li>
+          <a href={`/blog/${post.id}/`}>{post.data.title}</a>
+          <FormattedDate date={post.data.pubDate} />
+        </li>
+      ))}
+    </ul>
+  </section>
+</aside>
+
+<style>
+  .sidebar {
+    padding: 1em;
+    background: rgb(var(--gray-light));
+    border-radius: 12px;
+    width: 280px;
+  }
+  h3 {
+    margin-top: 0;
+  }
+  ul {
+    list-style: none;
+    padding-left: 0;
+  }
+  li {
+    margin-bottom: 0.5em;
+  }
+  a {
+    text-decoration: none;
+  }
+  .count {
+    margin-left: 0.5em;
+    color: rgb(var(--gray));
+  }
+</style>

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -12,6 +12,8 @@ const blog = defineCollection({
     pubDate: z.coerce.date(),
     updatedDate: z.coerce.date().optional(),
     heroImage: z.string().optional(),
+    views: z.number().default(0),
+    likes: z.number().default(0),
   }),
 });
 

--- a/src/content/blog/first-post.md
+++ b/src/content/blog/first-post.md
@@ -3,6 +3,8 @@ title: "First post"
 description: "Lorem ipsum dolor sit amet"
 pubDate: "Jul 08 2022"
 heroImage: "/blog-placeholder-3.jpg"
+views: 120
+likes: 30
 ---
 
 Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Vitae ultricies leo integer malesuada nunc vel risus commodo viverra. Adipiscing enim eu turpis egestas pretium. Euismod elementum nisi quis eleifend quam adipiscing. In hac habitasse platea dictumst vestibulum. Sagittis purus sit amet volutpat. Netus et malesuada fames ac turpis egestas. Eget magna fermentum iaculis eu non diam phasellus vestibulum lorem. Varius sit amet mattis vulputate enim. Habitasse platea dictumst quisque sagittis. Integer quis auctor elit sed vulputate mi. Dictumst quisque sagittis purus sit amet.

--- a/src/content/blog/markdown-style-guide.md
+++ b/src/content/blog/markdown-style-guide.md
@@ -3,6 +3,8 @@ title: "Markdown Style Guide"
 description: "Here is a sample of some basic Markdown syntax that can be used when writing Markdown content in Astro."
 pubDate: "Jun 19 2024"
 heroImage: "/blog-placeholder-1.jpg"
+views: 80
+likes: 25
 ---
 
 Here is a sample of some basic Markdown syntax that can be used when writing Markdown content in Astro.

--- a/src/content/blog/second-post.md
+++ b/src/content/blog/second-post.md
@@ -3,6 +3,8 @@ title: "Second post"
 description: "Lorem ipsum dolor sit amet"
 pubDate: "Jul 15 2022"
 heroImage: "/blog-placeholder-4.jpg"
+views: 150
+likes: 45
 ---
 
 Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Vitae ultricies leo integer malesuada nunc vel risus commodo viverra. Adipiscing enim eu turpis egestas pretium. Euismod elementum nisi quis eleifend quam adipiscing. In hac habitasse platea dictumst vestibulum. Sagittis purus sit amet volutpat. Netus et malesuada fames ac turpis egestas. Eget magna fermentum iaculis eu non diam phasellus vestibulum lorem. Varius sit amet mattis vulputate enim. Habitasse platea dictumst quisque sagittis. Integer quis auctor elit sed vulputate mi. Dictumst quisque sagittis purus sit amet.

--- a/src/content/blog/third-post.md
+++ b/src/content/blog/third-post.md
@@ -3,6 +3,8 @@ title: "Third post"
 description: "Lorem ipsum dolor sit amet"
 pubDate: "Jul 22 2022"
 heroImage: "/blog-placeholder-2.jpg"
+views: 200
+likes: 60
 ---
 
 Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Vitae ultricies leo integer malesuada nunc vel risus commodo viverra. Adipiscing enim eu turpis egestas pretium. Euismod elementum nisi quis eleifend quam adipiscing. In hac habitasse platea dictumst vestibulum. Sagittis purus sit amet volutpat. Netus et malesuada fames ac turpis egestas. Eget magna fermentum iaculis eu non diam phasellus vestibulum lorem. Varius sit amet mattis vulputate enim. Habitasse platea dictumst quisque sagittis. Integer quis auctor elit sed vulputate mi. Dictumst quisque sagittis purus sit amet.

--- a/src/content/blog/using-mdx.mdx
+++ b/src/content/blog/using-mdx.mdx
@@ -3,6 +3,8 @@ title: "Using MDX"
 description: "Lorem ipsum dolor sit amet"
 pubDate: "Jun 01 2024"
 heroImage: "/blog-placeholder-5.jpg"
+views: 50
+likes: 15
 ---
 
 This theme comes with the [@astrojs/mdx](https://docs.astro.build/en/guides/integrations-guide/mdx/) integration installed and configured in your `astro.config.mjs` config file. If you prefer not to use MDX, you can disable support by removing the integration from your config file.

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -5,6 +5,7 @@ import Footer from '../../components/Footer.astro';
 import { SITE_TITLE, SITE_DESCRIPTION } from '../../consts';
 import { getCollection } from 'astro:content';
 import FormattedDate from '../../components/FormattedDate.astro';
+import Sidebar from '../../components/Sidebar.astro';
 
 const posts = (await getCollection('blog')).sort(
 	(a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf(),
@@ -16,12 +17,19 @@ const posts = (await getCollection('blog')).sort(
 	<head>
 		<BaseHead title={SITE_TITLE} description={SITE_DESCRIPTION} />
 		<style>
-			main {
-				width: 960px;
-			}
-			ul {
-				display: flex;
-				flex-wrap: wrap;
+                        main {
+                                width: 960px;
+                        }
+                        .layout {
+                                display: flex;
+                                gap: 2rem;
+                        }
+                        .layout section {
+                                flex: 1;
+                        }
+                        ul {
+                                display: flex;
+                                flex-wrap: wrap;
 				gap: 2rem;
 				list-style-type: none;
 				margin: 0;
@@ -76,19 +84,23 @@ const posts = (await getCollection('blog')).sort(
 					width: 100%;
 					text-align: center;
 				}
-				ul li:first-child {
-					margin-bottom: 0;
-				}
-				ul li:first-child .title {
-					font-size: 1.563em;
-				}
-			}
-		</style>
+                                ul li:first-child {
+                                        margin-bottom: 0;
+                                }
+                                ul li:first-child .title {
+                                        font-size: 1.563em;
+                                }
+                                .layout {
+                                        flex-direction: column;
+                                }
+                        }
+                </style>
 	</head>
 	<body>
 		<Header />
-		<main>
-			<section>
+                <main>
+                        <div class="layout">
+                        <section>
 				<ul>
 					{
 						posts.map((post) => (
@@ -104,8 +116,10 @@ const posts = (await getCollection('blog')).sort(
 						))
 					}
 				</ul>
-			</section>
-		</main>
+                        </section>
+                        <Sidebar />
+                        </div>
+                </main>
 		<Footer />
 	</body>
 </html>


### PR DESCRIPTION
## Summary
- add view and like counts to blog posts
- extend blog post schema to include views and likes
- create `Sidebar` component listing popular and latest posts
- display sidebar on blog index page

## Testing
- `npm install`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_6862a2091900832c8db02a1c94f8c878