### PR TITLE
Add privacy policy page and update footer

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -3,7 +3,12 @@ const today = new Date();
 ---
 
 <footer>
+	<div class="copyright">
 	&copy; {today.getFullYear()} Your name here. All rights reserved.
+	</div>
+	<div class="privacy">
+	<a href="/privacy">Privacy Policy</a>
+	</div>
 	<div class="social-links">
 		<a href="https://m.webtoo.ls/@astro" target="_blank">
 			<span class="sr-only">Follow Astro on Mastodon</span>
@@ -57,6 +62,17 @@ const today = new Date();
 		color: rgb(var(--gray));
 	}
 	.social-links a:hover {
-		color: rgb(var(--gray-dark));
+	color: rgb(var(--gray-dark));
+	}
+	.privacy {
+	margin-top: 0.5em;
+	}
+	.privacy a {
+	text-decoration: none;
+	color: rgb(var(--gray));
+	}
+	.privacy a:hover {
+	color: rgb(var(--gray-dark));
+	text-decoration: underline;
 	}
 </style>

--- a/src/pages/privacy.astro
+++ b/src/pages/privacy.astro
@@ -1,0 +1,22 @@
+---
+import BaseHead from '../components/BaseHead.astro';
+import Header from '../components/Header.astro';
+import Footer from '../components/Footer.astro';
+---
+
+<!doctype html>
+<html lang="en">
+	<head>
+		<BaseHead title="Privacy Policy" description="Privacy policy information" />
+	</head>
+	<body>
+		<Header />
+		<main>
+			<h1>Privacy Policy</h1>
+			<p>
+				We respect your privacy. This site collects only the data necessary to provide its services.
+			</p>
+		</main>
+		<Footer />
+	</body>
+</html>


### PR DESCRIPTION
## Summary
- update the footer with a copyright section and privacy policy link
- add new `privacy` page describing privacy policy

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6862a2505d14832c8ebe9a790b8f528d