### PR TITLE
Add contact & update about page

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -1,9 +1,10 @@
 ---
+import { SITE_TITLE } from '../consts';
 const today = new Date();
 ---
 
 <footer>
-	&copy; {today.getFullYear()} Your name here. All rights reserved.
+        &copy; {today.getFullYear()} {SITE_TITLE}. Wszelkie prawa zastrzeżone.
 	<div class="social-links">
 		<a href="https://m.webtoo.ls/@astro" target="_blank">
 			<span class="sr-only">Follow Astro on Mastodon</span>

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -6,11 +6,12 @@ import { SITE_TITLE } from '../consts';
 <header>
 	<nav>
 		<h2><a href="/">{SITE_TITLE}</a></h2>
-		<div class="internal-links">
-			<HeaderLink href="/">Home</HeaderLink>
-			<HeaderLink href="/blog">Blog</HeaderLink>
-			<HeaderLink href="/about">About</HeaderLink>
-		</div>
+                <div class="internal-links">
+                        <HeaderLink href="/">Home</HeaderLink>
+                        <HeaderLink href="/blog">Blog</HeaderLink>
+                        <HeaderLink href="/about">About</HeaderLink>
+                        <HeaderLink href="/contact">Kontakt</HeaderLink>
+                </div>
 		<div class="social-links">
 			<a href="https://m.webtoo.ls/@astro" target="_blank">
 				<span class="sr-only">Follow Astro on Mastodon</span>

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -3,3 +3,4 @@
 
 export const SITE_TITLE = "pseudointelekt.pl";
 export const SITE_DESCRIPTION = "Blog Pseudointelekt";
+export const CONTACT_EMAIL = "info@pseidointelekt.pl";

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -1,62 +1,18 @@
 ---
 import Layout from '../layouts/BlogPost.astro';
+import { CONTACT_EMAIL } from '../consts';
 ---
 
 <Layout
-	title="About Me"
-	description="Lorem ipsum dolor sit amet"
-	pubDate={new Date('August 08 2021')}
-	heroImage="/blog-placeholder-about.jpg"
+  title="O mnie"
+  description="Kilka słów o autorze"
+  pubDate={new Date('August 08 2021')}
+  heroImage="/blog-placeholder-about.jpg"
 >
-	<p>
-		Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut
-		labore et dolore magna aliqua. Vitae ultricies leo integer malesuada nunc vel risus commodo
-		viverra. Adipiscing enim eu turpis egestas pretium. Euismod elementum nisi quis eleifend quam
-		adipiscing. In hac habitasse platea dictumst vestibulum. Sagittis purus sit amet volutpat. Netus
-		et malesuada fames ac turpis egestas. Eget magna fermentum iaculis eu non diam phasellus
-		vestibulum lorem. Varius sit amet mattis vulputate enim. Habitasse platea dictumst quisque
-		sagittis. Integer quis auctor elit sed vulputate mi. Dictumst quisque sagittis purus sit amet.
-	</p>
-
-	<p>
-		Morbi tristique senectus et netus. Id semper risus in hendrerit gravida rutrum quisque non
-		tellus. Habitasse platea dictumst quisque sagittis purus sit amet. Tellus molestie nunc non
-		blandit massa. Cursus vitae congue mauris rhoncus. Accumsan tortor posuere ac ut. Fringilla urna
-		porttitor rhoncus dolor. Elit ullamcorper dignissim cras tincidunt lobortis. In cursus turpis
-		massa tincidunt dui ut ornare lectus. Integer feugiat scelerisque varius morbi enim nunc.
-		Bibendum neque egestas congue quisque egestas diam. Cras ornare arcu dui vivamus arcu felis
-		bibendum. Dignissim suspendisse in est ante in nibh mauris. Sed tempus urna et pharetra pharetra
-		massa massa ultricies mi.
-	</p>
-
-	<p>
-		Mollis nunc sed id semper risus in. Convallis a cras semper auctor neque. Diam sit amet nisl
-		suscipit. Lacus viverra vitae congue eu consequat ac felis donec. Egestas integer eget aliquet
-		nibh praesent tristique magna sit amet. Eget magna fermentum iaculis eu non diam. In vitae
-		turpis massa sed elementum. Tristique et egestas quis ipsum suspendisse ultrices. Eget lorem
-		dolor sed viverra ipsum. Vel turpis nunc eget lorem dolor sed viverra. Posuere ac ut consequat
-		semper viverra nam. Laoreet suspendisse interdum consectetur libero id faucibus. Diam phasellus
-		vestibulum lorem sed risus ultricies tristique. Rhoncus dolor purus non enim praesent elementum
-		facilisis. Ultrices tincidunt arcu non sodales neque. Tempus egestas sed sed risus pretium quam
-		vulputate. Viverra suspendisse potenti nullam ac tortor vitae purus faucibus ornare. Fringilla
-		urna porttitor rhoncus dolor purus non. Amet dictum sit amet justo donec enim.
-	</p>
-
-	<p>
-		Mattis ullamcorper velit sed ullamcorper morbi tincidunt. Tortor posuere ac ut consequat semper
-		viverra. Tellus mauris a diam maecenas sed enim ut sem viverra. Venenatis urna cursus eget nunc
-		scelerisque viverra mauris in. Arcu ac tortor dignissim convallis aenean et tortor at. Curabitur
-		gravida arcu ac tortor dignissim convallis aenean et tortor. Egestas tellus rutrum tellus
-		pellentesque eu. Fusce ut placerat orci nulla pellentesque dignissim enim sit amet. Ut enim
-		blandit volutpat maecenas volutpat blandit aliquam etiam. Id donec ultrices tincidunt arcu. Id
-		cursus metus aliquam eleifend mi.
-	</p>
-
-	<p>
-		Tempus quam pellentesque nec nam aliquam sem. Risus at ultrices mi tempus imperdiet. Id porta
-		nibh venenatis cras sed felis eget velit. Ipsum a arcu cursus vitae. Facilisis magna etiam
-		tempor orci eu lobortis elementum. Tincidunt dui ut ornare lectus sit. Quisque non tellus orci
-		ac. Blandit libero volutpat sed cras. Nec tincidunt praesent semper feugiat nibh sed pulvinar
-		proin gravida. Egestas integer eget aliquet nibh praesent tristique magna.
-	</p>
+  <p>
+    Cześć! Witaj na mojej stronie. Znajdziesz tutaj przemyślenia i artykuły na różne tematy, które szczególnie mnie interesują.
+  </p>
+  <p>
+    Jeśli masz pytania lub uwagi, napisz do mnie na adres <a href={`mailto:${CONTACT_EMAIL}`}>{CONTACT_EMAIL}</a> albo skorzystaj z formularza w zakładce <a href="/contact">Kontakt</a>.
+  </p>
 </Layout>

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -1,0 +1,55 @@
+---
+import BaseHead from '../components/BaseHead.astro';
+import Header from '../components/Header.astro';
+import Footer from '../components/Footer.astro';
+import { CONTACT_EMAIL } from '../consts';
+---
+
+<!doctype html>
+<html lang="pl">
+  <head>
+    <BaseHead title="Kontakt" description="Skontaktuj się z nami" />
+    <style>
+      form {
+        display: flex;
+        flex-direction: column;
+        gap: 0.5em;
+        margin-top: 1em;
+      }
+      label {
+        display: flex;
+        flex-direction: column;
+      }
+      input, textarea {
+        padding: 0.5em;
+      }
+      button {
+        width: max-content;
+        padding: 0.5em 1em;
+      }
+    </style>
+  </head>
+  <body>
+    <Header />
+    <main>
+      <h1>Kontakt</h1>
+      <p>Jeśli masz pytania, napisz na <a href={`mailto:${CONTACT_EMAIL}`}>{CONTACT_EMAIL}</a> lub skorzystaj z formularza poniżej.</p>
+      <form action={`mailto:${CONTACT_EMAIL}`} method="post" enctype="text/plain">
+        <label>
+          Imię
+          <input type="text" name="name" required />
+        </label>
+        <label>
+          Email
+          <input type="email" name="email" required />
+        </label>
+        <label>
+          Wiadomość
+          <textarea name="message" rows="5" required></textarea>
+        </label>
+        <button type="submit">Wyślij</button>
+      </form>
+    </main>
+    <Footer />
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add CONTACT_EMAIL constant
- update header with Contact link
- customize footer copy
- add a Contact page with a mailto form
- replace About page content referencing Contact page

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_6862a2d5c904832c832a58e53c9e7ad8