### PR TITLE
Add CF deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,28 @@
+name: Deploy to Cloudflare
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Install dependencies
+        run: npm ci
+      - name: Build
+        run: npm run build
+      - name: Deploy
+        run: npx wrangler deploy
+        env:
+          CF_API_TOKEN: ${{ secrets.CF_API_TOKEN }}
+          CF_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CF_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}

--- a/README.md
+++ b/README.md
@@ -58,6 +58,34 @@ All commands are run from the root of the project, from a terminal:
 | `npm run astro -- --help` | Get help using the Astro CLI                     |
 | `npm run deploy`          | Deploy your production site to Cloudflare        |
 
+## Continuous deployment
+
+This repo contains a GitHub Actions workflow (`.github/workflows/deploy.yml`) that
+builds and deploys the site whenever changes are pushed to the `main` branch.
+
+### Secrets configuration
+
+Create the following repository secrets under **Settings → Secrets and variables → Actions**:
+
+- `CF_API_TOKEN` – a Cloudflare API token with Workers deploy permissions.
+- `CF_ACCOUNT_ID` – your Cloudflare account ID.
+
+These values are provided to `wrangler` during deployment.
+
+### Enabling the schedule
+
+To run deployments on a schedule, add a `schedule` block to the workflow. For example:
+
+```yaml
+on:
+  push:
+    branches: [main]
+  schedule:
+    - cron: '0 3 * * *'
+```
+
+GitHub will execute the workflow according to the cron expression after the change is pushed.
+
 ## 👀 Want to learn more?
 
 Check out [our documentation](https://docs.astro.build) or jump into our [Discord server](https://astro.build/chat).


### PR DESCRIPTION
## Summary
- automate deployment via GitHub Actions
- document how to configure deployment secrets and optional schedule

## Testing
- `npm ci`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6862a7470a90832c9aaf70db880abb7f