### PR TITLE
Fix horizontal overflow in Hero section

### DIFF
--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -48,8 +48,8 @@
         position: relative;
         text-align: center;
         padding: 4em 1em;
-        width: 100vw;
-        margin-left: calc(50% - 50vw);
+        width: 100%;
+        margin: 0;
         background: radial-gradient(circle at var(--cursor-x, 50%) var(--cursor-y, 50%), rgba(255,255,255,0.2), transparent 60%), var(--royal-green);
         color: var(--ivory);
         overflow: hidden;


### PR DESCRIPTION
## Summary
- ensure the Hero section never exceeds the viewport width

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_6862a9e17588832c81df3461bda19acd