### PR TITLE
Add deployment schedule

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - main
+  # Automatically deploy every day at 03:00 UTC when scheduling is enabled
+  schedule:
+    - cron: '0 3 * * *'
 
 jobs:
   deploy:

--- a/README.md
+++ b/README.md
@@ -72,19 +72,16 @@ Create the following repository secrets under **Settings → Secrets and variabl
 
 These values are provided to `wrangler` during deployment.
 
-### Enabling the schedule
+### Scheduled deployments
 
-To run deployments on a schedule, add a `schedule` block to the workflow. For example:
+The deployment workflow includes a `schedule` trigger:
 
 ```yaml
-on:
-  push:
-    branches: [main]
-  schedule:
-    - cron: '0 3 * * *'
+schedule:
+  - cron: '0 3 * * *'
 ```
 
-GitHub will execute the workflow according to the cron expression after the change is pushed.
+GitHub will run the workflow automatically every day at **03:00&nbsp;UTC** when scheduled workflows are enabled for the repository.
 
 ## 👀 Want to learn more?
 


### PR DESCRIPTION
## Summary
- run daily deployment at 03:00 UTC
- document that schedule in README

## Testing
- `npm install`
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_6862aa795cfc832c9300fe54dbb96911