### PR TITLE
Load Cron prompt from file

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,12 @@ on:
 
 GitHub will execute the workflow according to the cron expression after the change is pushed.
 
+### Customizing the AI post prompt
+
+The worker uses the text in `src/prompt/blog-post.txt` when requesting a new
+post from OpenAI. Edit this file to change the prompt and redeploy the project
+for your changes to take effect.
+
 ## 👀 Want to learn more?
 
 Check out [our documentation](https://docs.astro.build) or jump into our [Discord server](https://astro.build/chat).

--- a/src/cron-worker.ts
+++ b/src/cron-worker.ts
@@ -4,6 +4,8 @@ export interface Env {
   GITHUB_REPO: string; // owner/repo
 }
 
+import blogPostPrompt from "./prompt/blog-post.txt?raw";
+
 function slugify(text: string) {
   return text.toLowerCase().replace(/\s+/g, "-").replace(/[^a-z0-9-]/g, "");
 }
@@ -11,6 +13,8 @@ function slugify(text: string) {
 export default {
   async scheduled(event: ScheduledEvent, env: Env, ctx: ExecutionContext) {
     const date = new Date(event.scheduledTime).toISOString().split("T")[0];
+
+    const prompt = blogPostPrompt.replace("${date}", date);
 
     const aiRes = await fetch("https://api.openai.com/v1/chat/completions", {
       method: "POST",
@@ -23,7 +27,7 @@ export default {
         messages: [
           {
             role: "user",
-            content: `Generate a short blog post in Markdown with YAML front matter containing a title and pubDate set to ${date}. Return only the Markdown.`,
+            content: prompt,
           },
         ],
       }),

--- a/src/prompt/blog-post.txt
+++ b/src/prompt/blog-post.txt
@@ -1,0 +1,1 @@
+Generate a short blog post in Markdown with YAML front matter containing a title and pubDate set to ${date}. Return only the Markdown.


### PR DESCRIPTION
## Summary
- store the blog post prompt in `src/prompt/blog-post.txt`
- import the prompt text in `cron-worker.ts`
- document the prompt file location and how to change it

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_6862aa78b238832cb1c69075b4d708ea