### PR TITLE
Improve header menu spacing

### DIFF
--- a/src/components/Menu.astro
+++ b/src/components/Menu.astro
@@ -12,5 +12,6 @@ import HeaderLink from './HeaderLink.astro';
     .menu {
         display: flex;
         align-items: center;
+        gap: 1rem;
     }
 </style>


### PR DESCRIPTION
## Summary
- give some breathing space between menu items in the header

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_6862aae96e1c832cb32e68ab7b8391f1