### PR TITLE
Add animated header with scroll effects

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -4,7 +4,6 @@ import Menu from './Menu.astro';
 ---
 
 <header>
-
         <nav>
                 <a href="/" class="logo">
                         <img src="/logo.svg" alt={SITE_TITLE} width="40" height="40" />
@@ -12,13 +11,49 @@ import Menu from './Menu.astro';
                 <Menu />
         </nav>
 </header>
+<script>
+        const header = document.querySelector('header');
+        let lastScroll = window.scrollY;
+        window.addEventListener('scroll', () => {
+                const current = window.scrollY;
+                if (current > lastScroll && current > header.offsetHeight) {
+                        header.classList.add('hidden');
+                } else {
+                        header.classList.remove('hidden');
+                }
+                lastScroll = current;
+        });
+        header.addEventListener('mousemove', (e) => {
+                const rect = header.getBoundingClientRect();
+                const x = e.clientX - rect.left - rect.width / 2;
+                const y = e.clientY - rect.top - rect.height / 2;
+                const rotateX = (y / rect.height) * 8;
+                const rotateY = -(x / rect.width) * 8;
+                header.style.setProperty('--rotate-x', `${rotateX}deg`);
+                header.style.setProperty('--rotate-y', `${rotateY}deg`);
+        });
+        header.addEventListener('mouseleave', () => {
+                header.style.setProperty('--rotate-x', `0deg`);
+                header.style.setProperty('--rotate-y', `0deg`);
+        });
+</script>
 <style>
-	header {
-		margin: 0;
-		padding: 0 1em;
-		background: white;
-		box-shadow: 0 2px 8px rgba(var(--black), 5%);
-	}
+        header {
+                margin: 0;
+                padding: 0 1em;
+                background: white;
+                box-shadow: 0 2px 8px rgba(var(--black), 5%);
+                position: fixed;
+                top: 0;
+                left: 0;
+                right: 0;
+                z-index: 10;
+                transition: top 0.3s ease, transform 0.2s ease;
+                transform: perspective(600px) rotateX(var(--rotate-x, 0)) rotateY(var(--rotate-y, 0));
+        }
+        header.hidden {
+                top: -100%;
+        }
         .logo {
                 display: flex;
                 align-items: center;
@@ -30,16 +65,23 @@ import Menu from './Menu.astro';
                 display: flex;
                 align-items: center;
                 justify-content: space-between;
+                perspective: 600px;
         }
-	nav a {
-		padding: 1em 0.5em;
-		color: var(--black);
-		border-bottom: 4px solid transparent;
-		text-decoration: none;
-	}
-	nav a.active {
-		text-decoration: none;
-		border-bottom-color: var(--accent);
-	}
+        nav a {
+                position: relative;
+                padding: 1em 0.75em;
+                color: var(--black);
+                text-decoration: none;
+                transition: color 0.3s, transform 0.2s;
+        }
+        nav a:hover {
+                color: var(--accent);
+                box-shadow: inset 0 0 0 2px var(--accent);
+                transform: translateZ(5px);
+        }
+        nav a.active {
+                text-decoration: none;
+                box-shadow: inset 0 0 0 2px var(--accent);
+        }
 
 </style>


### PR DESCRIPTION
## Summary
- make the header fixed and hide it while scrolling down
- add mousemove rotation for a small 3D effect
- highlight menu items with a square outline

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_6862ac287db4832c8e95b7cde2d157db