### PR TITLE
Disable mouse tracking banner

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -23,19 +23,6 @@ import Menu from './Menu.astro';
                 }
                 lastScroll = current;
         });
-        header.addEventListener('mousemove', (e) => {
-                const rect = header.getBoundingClientRect();
-                const x = e.clientX - rect.left - rect.width / 2;
-                const y = e.clientY - rect.top - rect.height / 2;
-                const rotateX = (y / rect.height) * 8;
-                const rotateY = -(x / rect.width) * 8;
-                header.style.setProperty('--rotate-x', `${rotateX}deg`);
-                header.style.setProperty('--rotate-y', `${rotateY}deg`);
-        });
-        header.addEventListener('mouseleave', () => {
-                header.style.setProperty('--rotate-x', `0deg`);
-                header.style.setProperty('--rotate-y', `0deg`);
-        });
 </script>
 <style>
         header {
@@ -48,8 +35,7 @@ import Menu from './Menu.astro';
                 left: 0;
                 right: 0;
                 z-index: 10;
-                transition: top 0.3s ease, transform 0.2s ease;
-                transform: perspective(600px) rotateX(var(--rotate-x, 0)) rotateY(var(--rotate-y, 0));
+                transition: top 0.3s ease;
         }
         header.hidden {
                 top: -100%;
@@ -65,7 +51,6 @@ import Menu from './Menu.astro';
                 display: flex;
                 align-items: center;
                 justify-content: space-between;
-                perspective: 600px;
         }
         nav a {
                 position: relative;
@@ -77,7 +62,7 @@ import Menu from './Menu.astro';
         nav a:hover {
                 color: var(--accent);
                 box-shadow: inset 0 0 0 2px var(--accent);
-                transform: translateZ(5px);
+                transform: scale(1.05);
         }
         nav a.active {
                 text-decoration: none;


### PR DESCRIPTION
## Summary
- remove mousemove-based rotation from header
- simplify header styles
- add slight scale transform for menu links on hover

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6863d676ce40832c8ed7400cedf70028