### PR TITLE
Fix header hover and page spacing

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -92,7 +92,7 @@ import Menu from './Menu.astro';
                 align-items: center;
                 height: 100%;
         }
-        nav a:hover {
+        nav a:hover:not(.logo) {
                 color: var(--accent);
                 box-shadow: inset 0 0 0 2px var(--accent);
                 transform: scale(1.05);

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -39,7 +39,7 @@
 body {
   font-family: "Atkinson", sans-serif;
   margin: 0;
-  padding: 0;
+  padding-top: 100px;
   text-align: left;
   background: var(--ivory);
   word-wrap: break-word;


### PR DESCRIPTION
## Summary
- avoid accent border when hovering over logo
- add 100px page offset to keep header from covering content

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6863df14ded4832c844a527b95d2a194