### PR TITLE
Handle contact form via Slack and KV

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,5 +54,13 @@ wrangler kv:namespace create pseudointelekt_contact_form
 ```
 Następnie w pliku `wrangler.json` dodaj uzyskany `id` i `preview_id` w sekcji `kv_namespaces` pod nazwą `pseudointelekt_contact_form`.
 
+Dodatkowo w sekcji `vars` umieść adres swojego webhooka Slack:
+
+```json
+  "vars": {
+    "SLACK_WEBHOOK_URL": "<YOUR_SLACK_WEBHOOK_URL>"
+  }
+```
+
 ### Personalizacja promptu
 Plik `src/prompt/blog-post.txt` definiuje prompt dla OpenAI. Edytuj go, aby dostosować generowane wpisy.

--- a/README.md
+++ b/README.md
@@ -43,7 +43,16 @@ Przed deployem skonfiguruj sekrety dla `wrangler secret`:
 wrangler secret put OPENAI_API_KEY
 wrangler secret put GITHUB_TOKEN
 wrangler secret put GITHUB_REPO
+wrangler secret put SLACK_WEBHOOK_URL
 ```
+
+### Konfiguracja bazy kontaktów
+Utwórz przestrzeń Cloudflare KV do przechowywania wysłanych formularzy:
+
+```bash
+wrangler kv:namespace create pseudointelekt_contact_form
+```
+Następnie w pliku `wrangler.json` dodaj uzyskany `id` i `preview_id` w sekcji `kv_namespaces` pod nazwą `pseudointelekt_contact_form`.
 
 ### Personalizacja promptu
 Plik `src/prompt/blog-post.txt` definiuje prompt dla OpenAI. Edytuj go, aby dostosować generowane wpisy.

--- a/src/cron-worker.ts
+++ b/src/cron-worker.ts
@@ -2,6 +2,8 @@ export interface Env {
   OPENAI_API_KEY: string;
   GITHUB_TOKEN: string;
   GITHUB_REPO: string; // owner/repo
+  SLACK_WEBHOOK_URL: string;
+  pseudointelekt_contact_form: KVNamespace;
 }
 
 import blogPostPrompt from "./prompt/blog-post.txt?raw";

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -34,7 +34,7 @@ import { CONTACT_EMAIL } from '../consts';
     <main>
       <h1>Kontakt</h1>
       <p>Jeśli masz pytania, napisz na <a href={`mailto:${CONTACT_EMAIL}`}>{CONTACT_EMAIL}</a> lub skorzystaj z formularza poniżej.</p>
-      <form action={`mailto:${CONTACT_EMAIL}`} method="post" enctype="text/plain">
+      <form id="contact-form" action="/api/contact" method="post">
         <label>
           Imię
           <input type="text" name="name" required />
@@ -49,7 +49,43 @@ import { CONTACT_EMAIL } from '../consts';
         </label>
         <button type="submit">Wyślij</button>
       </form>
+      <p id="status"></p>
     </main>
     <Footer />
+    <script type="module">
+      const form = document.getElementById('contact-form');
+      const status = document.getElementById('status');
+      form.addEventListener('submit', async (e) => {
+        e.preventDefault();
+        const data = new FormData(form);
+        const name = data.get('name').trim();
+        const email = data.get('email').trim();
+        const message = data.get('message').trim();
+        if (!name) {
+          status.textContent = 'Halo! Jak mamy Cię zawołać?';
+          status.style.color = 'red';
+          return;
+        }
+        if (!/^\S+@\S+\.\S+$/.test(email)) {
+          status.textContent = 'Podaj prawidłowy email – gołębie pocztowe nie obsługują tego formatu.';
+          status.style.color = 'red';
+          return;
+        }
+        if (!message) {
+          status.textContent = 'Serio nic nie napiszesz? Bez treści nie damy rady!';
+          status.style.color = 'red';
+          return;
+        }
+        const res = await fetch('/api/contact', { method: 'POST', body: data });
+        if (res.ok) {
+          status.textContent = 'Wiadomość wysłana';
+          status.style.color = 'green';
+          form.reset();
+        } else {
+          status.textContent = 'Błąd wysyłania';
+          status.style.color = 'red';
+        }
+      });
+    </script>
   </body>
 </html>

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -1,7 +1,43 @@
 import server from './_worker.js';
 import cron from './cron-worker';
 
+async function handleContact(request: Request, env: Env) {
+  const data = await request.formData();
+  const name = (data.get('name') || '').toString().trim();
+  const email = (data.get('email') || '').toString().trim();
+  const message = (data.get('message') || '').toString().trim();
+
+  if (!name || !email || !message || !/^\S+@\S+\.\S+$/.test(email)) {
+    return new Response('Invalid input', { status: 400 });
+  }
+
+  const payload = {
+    name,
+    email,
+    message,
+    date: new Date().toISOString(),
+  };
+
+  await fetch(env.SLACK_WEBHOOK_URL, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      text: `Nowa wiadomość od ${name} <${email}>:\n${message}`,
+    }),
+  });
+
+  await env.pseudointelekt_contact_form.put(`msg-${Date.now()}`, JSON.stringify(payload));
+
+  return new Response('OK', { status: 200 });
+}
+
 export default {
-  fetch: server.fetch,
+  async fetch(request: Request, env: Env, ctx: ExecutionContext) {
+    const url = new URL(request.url);
+    if (request.method === 'POST' && url.pathname === '/api/contact') {
+      return handleContact(request, env);
+    }
+    return server.fetch(request, env, ctx);
+  },
   scheduled: cron.scheduled,
 };

--- a/worker-configuration.d.ts
+++ b/worker-configuration.d.ts
@@ -5,4 +5,6 @@ interface Env {
         OPENAI_API_KEY: string;
         GITHUB_TOKEN: string;
         GITHUB_REPO: string;
+        SLACK_WEBHOOK_URL: string;
+        pseudointelekt_contact_form: KVNamespace;
 }

--- a/wrangler.json
+++ b/wrangler.json
@@ -7,6 +7,16 @@
     "directory": "./dist",
     "binding": "ASSETS"
   },
+  "kv_namespaces": [
+    {
+      "binding": "pseudointelekt_contact_form",
+      "id": "<YOUR_NAMESPACE_ID>",
+      "preview_id": "<YOUR_PREVIEW_ID>"
+    }
+  ],
+  "vars": {
+    "SLACK_WEBHOOK_URL": ""
+  },
   "observability": {
     "enabled": true
   },

--- a/wrangler.json
+++ b/wrangler.json
@@ -15,7 +15,7 @@
     }
   ],
   "vars": {
-    "SLACK_WEBHOOK_URL": ""
+    "SLACK_WEBHOOK_URL": "<YOUR_SLACK_WEBHOOK_URL>"
   },
   "observability": {
     "enabled": true


### PR DESCRIPTION
## Summary
- validate contact form client-side
- send form data to a new `/api/contact` endpoint
- implement Cloudflare worker route that forwards messages to Slack and logs them to a KV store
- extend environment typings for new variables
- funny validation messages and docs for Slack/KV setup
- rename contact KV namespace to `pseudointelekt_contact_form`

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_6863e126476c832cb6e0ec1176da3769