### PR TITLE
Fix KV namespace binding

### DIFF
--- a/wrangler.json
+++ b/wrangler.json
@@ -10,12 +10,12 @@
   "kv_namespaces": [
     {
       "binding": "pseudointelekt_contact_form",
-      "id": "<YOUR_NAMESPACE_ID>",
-      "preview_id": "<YOUR_PREVIEW_ID>"
+      "id": "b71f33f4cc0e48aaa96cf9aa53092882",
+      "preview_id": "b71f33f4cc0e48aaa96cf9aa53092882"
     }
   ],
   "vars": {
-    "SLACK_WEBHOOK_URL": "<YOUR_SLACK_WEBHOOK_URL>"
+    "SLACK_WEBHOOK_URL": "https://hooks.slack.com/services/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"
   },
   "observability": {
     "enabled": true


### PR DESCRIPTION
## Summary
- configure `wrangler.json` with proper KV namespace IDs
- set Slack webhook URL

## Testing
- `npm run build`
- `npm run check`



------
https://chatgpt.com/codex/tasks/task_e_6863ec5577e0832cab5edc00b2a7d6e7