### PR TITLE
Improve OpenAI error handling

### DIFF
--- a/src/modules/articleGenerator.ts
+++ b/src/modules/articleGenerator.ts
@@ -22,13 +22,20 @@ export async function generateArticle({ apiKey, prompt }: GenerateArticleOptions
       },
       body: JSON.stringify({
         model: 'gpt-4o',
-        messages: [
-          { role: 'user', content: prompt },
-        ],
+        messages: [{ role: 'user', content: prompt }],
       }),
     });
 
+    if (!res.ok) {
+      const msg = await res.text();
+      throw new Error(`OpenAI request failed: ${res.status} ${msg}`);
+    }
+
     const data: any = await res.json();
+    if (!data.choices || !data.choices[0]) {
+      throw new Error('OpenAI response missing choices');
+    }
+
     const text = data.choices[0].message.content.trim();
 
     try {

--- a/src/modules/heroImageGenerator.ts
+++ b/src/modules/heroImageGenerator.ts
@@ -22,7 +22,15 @@ export async function generateHeroImage({ apiKey, prompt }: GenerateHeroOptions)
       }),
     });
 
+    if (!res.ok) {
+      const msg = await res.text();
+      throw new Error(`OpenAI image request failed: ${res.status} ${msg}`);
+    }
+
     const data: any = await res.json();
+    if (!data.data || !data.data[0]) {
+      throw new Error('OpenAI image response missing data');
+    }
     const b64 = data.data[0].b64_json as string;
     logEvent({ type: 'generate-hero-complete' });
     return Buffer.from(b64, 'base64');


### PR DESCRIPTION
## Summary
- validate OpenAI chat response before using it
- validate OpenAI image generation response before using it

## Testing
- `npm run build`
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_68645e620030832cb1cbfab1ae959a48