### PR TITLE
Improve logging for article generation

### DIFF
--- a/src/modules/articleAssembler.ts
+++ b/src/modules/articleAssembler.ts
@@ -20,11 +20,13 @@ export async function assembleArticle({
   date,
 }: AssembleOptions): Promise<{ postPath: string; imagePath: string }> {
   logEvent({ type: 'assemble-start', title: article.title });
+  logEvent({ type: 'assemble-paths', blogDir, publicDir });
   const postDate = date || new Date().toISOString().split('T')[0];
   const slug = slugify(article.title);
 
   await fs.mkdir(publicDir, { recursive: true });
   await fs.mkdir(blogDir, { recursive: true });
+  logEvent({ type: 'assemble-dirs-ready' });
 
   const imageName = `${postDate}-${slug}.png`;
   const imagePath = path.join(publicDir, imageName);
@@ -44,6 +46,7 @@ export async function assembleArticle({
   const postPath = path.join(blogDir, postName);
   try {
     await fs.writeFile(postPath, fm + article.content);
+    logEvent({ type: 'assemble-files-written', postPath, imagePath });
     logEvent({ type: 'assemble-complete', postPath, imagePath });
     return { postPath, imagePath };
   } catch (err) {

--- a/src/modules/githubPublisher.ts
+++ b/src/modules/githubPublisher.ts
@@ -19,9 +19,10 @@ export async function publishArticleToGitHub({ env, article, heroImage, date }: 
     'User-Agent': 'article-publisher',
     'Content-Type': 'application/json',
   };
-
+  logEvent({ type: 'github-request-repo' });
   const repoRes = await fetch(repoUrl, { headers });
   const repo: any = await repoRes.json();
+  logEvent({ type: 'github-response-repo', status: repoRes.status });
   const branch = repo.default_branch;
 
   const imageName = `${postDate}-${slug}.png`;
@@ -38,6 +39,7 @@ export async function publishArticleToGitHub({ env, article, heroImage, date }: 
   ].join('\n');
 
   try {
+    logEvent({ type: 'github-upload-post', file: postName });
     await fetch(`${repoUrl}/contents/${encodeURIComponent(`src/content/blog/${postName}`)}`, {
       method: 'PUT',
       headers,
@@ -49,6 +51,7 @@ export async function publishArticleToGitHub({ env, article, heroImage, date }: 
     });
 
   const heroBase64 = heroImage.toString('base64');
+    logEvent({ type: 'github-upload-image', file: imageName });
     await fetch(`${repoUrl}/contents/${encodeURIComponent(`public/blog-images/${imageName}`)}`, {
       method: 'PUT',
       headers,

--- a/src/modules/heroImageGenerator.ts
+++ b/src/modules/heroImageGenerator.ts
@@ -7,6 +7,7 @@ export interface GenerateHeroOptions {
 
 export async function generateHeroImage({ apiKey, prompt }: GenerateHeroOptions): Promise<Buffer> {
   logEvent({ type: 'generate-hero-start' });
+  logEvent({ type: 'openai-image-request', promptSnippet: prompt.slice(0, 100) });
   try {
     const res = await fetch('https://api.openai.com/v1/images/generations', {
       method: 'POST',
@@ -22,12 +23,15 @@ export async function generateHeroImage({ apiKey, prompt }: GenerateHeroOptions)
       }),
     });
 
+    logEvent({ type: 'openai-image-response-status', status: res.status });
+
     if (!res.ok) {
       const msg = await res.text();
       throw new Error(`OpenAI image request failed: ${res.status} ${msg}`);
     }
 
     const data: any = await res.json();
+    logEvent({ type: 'openai-image-response-received' });
     if (!data.data || !data.data[0]) {
       throw new Error('OpenAI image response missing data');
     }

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -46,6 +46,7 @@ async function handleContact(request: Request, env: Env) {
 
 async function handleGenerateArticle(request: Request, env: Env) {
   logEvent({ type: 'generate-article-endpoint-start' });
+  logEvent({ type: 'endpoint-request-id', id: crypto.randomUUID() });
   try {
     const article = await generateArticle({ apiKey: env.OPENAI_API_KEY, prompt: articlePrompt });
     const heroPrompt = heroTemplate.replace('{title}', article.title);


### PR DESCRIPTION
## Summary
- enhance logging in article generation modules
- ensure each OpenAI and GitHub operation logs start and status
- add extra events in `assembleArticle` and worker endpoint

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_6865011bfc5c832cad9d5da937145454