### PR TITLE
Fix hero image size to 1024x1024

### DIFF
--- a/src/modules/heroImageGenerator.ts
+++ b/src/modules/heroImageGenerator.ts
@@ -18,7 +18,7 @@ export async function generateHeroImage({ apiKey, prompt }: GenerateHeroOptions)
       body: JSON.stringify({
         prompt,
         n: 1,
-        size: '1024x512',
+        size: '1024x1024',
         response_format: 'b64_json',
       }),
     });

--- a/src/prompt/hero-image.txt
+++ b/src/prompt/hero-image.txt
@@ -1,1 +1,1 @@
-Ilustracja przedstawiająca temat artykułu "{title}" w zabawnym, komiksowym stylu. Żywe kolory, szeroki kadr 16:9.
+Ilustracja przedstawiająca temat artykułu "{title}" w zabawnym, komiksowym stylu. Żywe kolory, kwadratowy kadr 1:1.


### PR DESCRIPTION
## Summary
- fix hero image generation to use a 1024x1024 size
- update the hero image prompt to mention a square (1:1) aspect ratio

## Testing
- `npm run build` *(fails: astro not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865111f7ebc832c8dacf0b07e62d2ad