### PR TITLE
Add views and likes defaults

### DIFF
--- a/src/content/blog/_template.md.sample
+++ b/src/content/blog/_template.md.sample
@@ -5,6 +5,8 @@ pubDate: "yyyy-mm-dd"
 # Optional fields
 updatedDate: "yyyy-mm-dd"
 heroImage: "/path/to/image.jpg"
+views: 0
+likes: 0
 ---
 
 Write your article content here using Markdown or MDX.

--- a/src/modules/articleAssembler.ts
+++ b/src/modules/articleAssembler.ts
@@ -38,6 +38,8 @@ export async function assembleArticle({
     `description: "${article.description}"`,
     `pubDate: "${postDate}"`,
     `heroImage: "/blog-images/${imageName}"`,
+    'views: 0',
+    'likes: 0',
     '---',
     '',
   ].join('\n');

--- a/src/modules/githubPublisher.ts
+++ b/src/modules/githubPublisher.ts
@@ -49,6 +49,8 @@ export async function publishArticleToGitHub({ env, article, heroImage, date }: 
     `description: "${article.description}"`,
     `pubDate: "${postDate}"`,
     `heroImage: "/blog-images/${imageName}"`,
+    'views: 0',
+    'likes: 0',
     '---',
     '',
     article.content,


### PR DESCRIPTION
## Summary
- include `views: 0` and `likes: 0` in generated front matter
- update article template with the same fields

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_6872e07d2970832caf292fde19db487b