### PR TITLE
Improve hero image generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ Plik `src/prompt/blog-post.txt` definiuje prompt dla OpenAI. Edytuj go, aby dost
 ### Automatyczne generowanie nowych wpisów
 Moduły w katalogu `src/modules` pozwalają na wygenerowanie treści artykułu oraz hero obrazka z wykorzystaniem API OpenAI. Przykładowe prompty znajdują się w `src/prompt/article-content.txt` oraz `src/prompt/hero-image.txt`.
 
+Hero obrazy są generowane przez model DALL·E 3. Funkcja `generateHeroImage()` przyjmuje opcjonalne parametry `style` i `quality`, które domyślnie ustawiono na `vivid` i `hd`, aby uzyskać wyraźny efekt zbliżony do tego w ChatGPT.
+
 Do złożenia i zacommitowania wpisu służy skrypt `scripts/publish-article.ts`:
 
 ```bash

--- a/src/modules/heroImageGenerator.ts
+++ b/src/modules/heroImageGenerator.ts
@@ -9,9 +9,19 @@ export interface GenerateHeroOptions {
    * '256x256', '512x512' and '1024x1024'. Defaults to '1024x1024'.
    */
   size?: '256x256' | '512x512' | '1024x1024';
+  /**
+   * Style variant for DALL·E 3. 'vivid' is more saturated and dynamic,
+   * while 'natural' is more realistic. Defaults to 'vivid'.
+   */
+  style?: 'vivid' | 'natural';
+  /**
+   * Image quality for DALL·E 3. 'standard' is faster, 'hd' yields
+   * crisper images similar to ChatGPT. Defaults to 'hd'.
+   */
+  quality?: 'standard' | 'hd';
 }
 
-export async function generateHeroImage({ apiKey, prompt, size = '1024x1024' }: GenerateHeroOptions): Promise<Buffer> {
+export async function generateHeroImage({ apiKey, prompt, size = '1024x1024', style = 'vivid', quality = 'hd' }: GenerateHeroOptions): Promise<Buffer> {
   logEvent({ type: 'generate-hero-start' });
   logEvent({ type: 'openai-image-request', promptSnippet: prompt.slice(0, 100) });
   try {
@@ -22,9 +32,12 @@ export async function generateHeroImage({ apiKey, prompt, size = '1024x1024' }: 
         Authorization: `Bearer ${apiKey}`,
       },
       body: JSON.stringify({
+        model: 'dall-e-3',
         prompt,
         n: 1,
         size,
+        style,
+        quality,
         response_format: 'b64_json',
       }),
       retries: 2,


### PR DESCRIPTION
## Summary
- clarify that hero images use DALL·E 3 with style/quality options
- allow hero image generator to request DALL·E 3 with `vivid`/`hd` defaults

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_6872e17186c4832c94425385f2e0f676