### PR TITLE
Remove duplicate top-liked posts segment

### DIFF
--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -8,11 +8,8 @@ import FormattedDate from '../../components/FormattedDate.astro';
 import Sidebar from '../../components/Sidebar.astro';
 
 const posts = (await getCollection('blog')).sort(
-        (a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf(),
+  (a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf(),
 );
-const topLiked = [...posts]
-        .sort((a, b) => (b.data.likes ?? 0) - (a.data.likes ?? 0))
-        .slice(0, 3);
 ---
 
 <!doctype html>
@@ -103,22 +100,6 @@ const topLiked = [...posts]
 		<Header />
                 <main>
                         <div class="layout">
-                        <section>
-                                <h2>Najwięcej polubień</h2>
-                                <ul>
-                                        {
-                                                topLiked.map((post) => (
-                                                        <li>
-                                                                <a href={`/blog/${post.id}/`}>
-                                                                        <img width={720} height={360} src={post.data.heroImage} alt="" />
-                                                                        <h4 class="title">{post.data.title}</h4>
-                                                                        <p class="date"><FormattedDate date={post.data.pubDate} /></p>
-                                                                </a>
-                                                        </li>
-                                                ))
-                                        }
-                                </ul>
-                        </section>
                         <section>
                                 <ul>
                                         {


### PR DESCRIPTION
## Summary
- show only the newest posts on the blog index
- keep the sidebar list of most liked, most viewed and newest posts

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_6872efb65680832c95b42a35759a31dd