### PR TITLE
Enable auto create for missing like counts

### DIFF
--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -114,7 +114,7 @@ const {
                                         const el = document.getElementById('view-count');
                                         if (el) el.textContent = d.views;
                                 });
-                        fetch('/api/likes')
+                        fetch(`/api/likes?slugs=${slug}`)
                                 .then((r) => r.ok ? r.json() : {})
                                 .then((d) => {
                                         const el = document.getElementById('like-count');

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -68,11 +68,15 @@ const topLiked = [...posts]
 				color: rgb(var(--black));
 				line-height: 1;
 			}
-			.date {
-				margin: 0;
-				color: rgb(var(--gray));
-			}
-			ul li a:hover h4,
+                        .date {
+                                margin: 0;
+                                color: rgb(var(--gray));
+                        }
+                        .count {
+                                margin-left: 0.5em;
+                                color: rgb(var(--gray));
+                        }
+                        ul li a:hover h4,
 			ul li a:hover .date {
 				color: rgb(var(--accent));
 			}
@@ -105,19 +109,20 @@ const topLiked = [...posts]
                         <div class="layout">
                         <section>
                                 <h2>Najwięcej polubień</h2>
-                                <ul>
+                               <ul id="top-liked-list">
                                         {
                                                 topLiked.map((post) => (
-                                                        <li>
+                                                        <li data-slug={post.id} data-likes={post.data.likes}>
                                                                 <a href={`/blog/${post.id}/`}>
                                                                         <img width={720} height={360} src={post.data.heroImage} alt="" />
                                                                         <h4 class="title">{post.data.title}</h4>
                                                                         <p class="date"><FormattedDate date={post.data.pubDate} /></p>
                                                                 </a>
+                                                                <span class="count">{post.data.likes}</span>
                                                         </li>
                                                 ))
                                         }
-                                </ul>
+                               </ul>
                         </section>
                         <section>
                                 <ul>
@@ -139,6 +144,29 @@ const topLiked = [...posts]
                         <Sidebar />
                         </div>
                 </main>
-		<Footer />
-	</body>
+               <Footer />
+               <script type="module">
+                       const list = document.getElementById('top-liked-list');
+                       if (list) {
+                               const items = Array.from(list.querySelectorAll('li'));
+                               const slugs = items.map((li) => li.dataset.slug).filter(Boolean).join(',');
+                               fetch(`/api/likes?slugs=${slugs}`)
+                                       .then((r) => (r.ok ? r.json() : {}))
+                                       .then((data) => {
+                                               items.forEach((li) => {
+                                                       const slug = li.dataset.slug;
+                                                       if (slug && data[slug] != null) {
+                                                               li.dataset.likes = data[slug];
+                                                               const span = li.querySelector('.count');
+                                                               if (span) span.textContent = data[slug];
+                                                       }
+                                               });
+                                               items.sort(
+                                                       (a, b) => parseInt(b.dataset.likes || '0') - parseInt(a.dataset.likes || '0')
+                                               );
+                                               items.forEach((li) => list.appendChild(li));
+                                       });
+                       }
+               </script>
+       </body>
 </html>

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -97,9 +97,10 @@ async function handleLike(request: Request, env: Env, slug: string) {
   });
 }
 
-async function handleGetLikes(env: Env) {
+async function handleGetLikes(env: Env, slugs: string[] = []) {
   const list = await env.pseudointelekt_likes.list();
   const data: Record<string, number> = {};
+
   for (const { name } of list.keys) {
     const value = await env.pseudointelekt_likes.get(name);
     if (value) {
@@ -107,6 +108,14 @@ async function handleGetLikes(env: Env) {
       data[slug] = parseInt(value);
     }
   }
+
+  for (const slug of slugs) {
+    if (data[slug] == null) {
+      await env.pseudointelekt_likes.put(`like-${slug}`, '0');
+      data[slug] = 0;
+    }
+  }
+
   return new Response(JSON.stringify(data), {
     headers: { 'Content-Type': 'application/json' },
   });
@@ -135,7 +144,9 @@ export default {
         return await handleLike(request, env, slug);
       }
       if (request.method === 'GET' && url.pathname === '/api/likes') {
-        return await handleGetLikes(env);
+        const slugsParam = url.searchParams.get('slugs');
+        const slugs = slugsParam ? slugsParam.split(',').filter(Boolean) : [];
+        return await handleGetLikes(env, slugs);
       }
       return await server.fetch(request, env, ctx);
     } catch (err) {


### PR DESCRIPTION
## Summary
- add `slugs` parameter to `/api/likes` to ensure counts exist for posts
- request like data for specific slugs in BlogPost and index pages

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6872f06332ec832ca6ac9f71c18a4068