### PR TITLE
Add KV initialization for view counter

### DIFF
--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -108,11 +108,15 @@ const {
                 <Footer />
                 <script type="module">
                         const slug = {JSON.stringify(slug)};
-                        fetch(`/api/views/${slug}`, { method: 'POST' })
-                                .then((r) => r.ok ? r.json() : { views: 0 })
-                                .then((d) => {
-                                        const el = document.getElementById('view-count');
-                                        if (el) el.textContent = d.views;
+                        const initialViews = {JSON.stringify(views ?? 0)};
+                        fetch(`/api/views-init/${slug}?value=${initialViews}`, { method: 'POST' })
+                                .finally(() => {
+                                        fetch(`/api/views/${slug}`, { method: 'POST' })
+                                                .then((r) => r.ok ? r.json() : { views: 0 })
+                                                .then((d) => {
+                                                        const el = document.getElementById('view-count');
+                                                        if (el) el.textContent = d.views;
+                                                });
                                 });
                         fetch('/api/likes')
                                 .then((r) => r.ok ? r.json() : {})

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -72,6 +72,23 @@ async function handleView(request: Request, env: Env, slug: string) {
   });
 }
 
+async function handleInitView(request: Request, env: Env, slug: string) {
+  const url = new URL(request.url);
+  const initial = parseInt(url.searchParams.get('value') || '0');
+  const key = `view-${slug}`;
+  const existing = await env.pseudointelekt_views.get(key);
+  if (!existing) {
+    await env.pseudointelekt_views.put(key, initial.toString());
+    return new Response(JSON.stringify({ views: initial }), {
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+  const current = parseInt(existing);
+  return new Response(JSON.stringify({ views: current }), {
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
 async function handleGetView(env: Env, slug: string) {
   const key = `view-${slug}`;
   const current = parseInt((await env.pseudointelekt_views.get(key)) || '0');
@@ -130,6 +147,10 @@ export default {
       }
       if (request.method === 'GET' && url.pathname === '/api/generate-article') {
         return await handleGenerateArticle(request, env);
+      }
+      if (request.method === 'POST' && url.pathname.startsWith('/api/views-init/')) {
+        const slug = url.pathname.substring('/api/views-init/'.length);
+        return await handleInitView(request, env, slug);
       }
       if (url.pathname.startsWith('/api/views/')) {
         const slug = url.pathname.substring('/api/views/'.length);


### PR DESCRIPTION
## Summary
- initialize page view counts in KV store
- expose `/api/views-init/:slug` to set initial value
- ensure blog posts call the init endpoint before incrementing

## Testing
- `npm run build`
- `npx tsc`
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_6872f21544e4832cb9ed8288be5d6de2