### PR TITLE
Add Cloudflare KV logging

### DIFF
--- a/src/cron-worker.ts
+++ b/src/cron-worker.ts
@@ -4,10 +4,11 @@ export interface Env {
   GITHUB_REPO: string; // owner/repo
   SLACK_WEBHOOK_URL: string;
   pseudointelekt_contact_form: KVNamespace;
+  pseudointelekt_logs: KVNamespace;
 }
 
 import blogPostPrompt from "./prompt/blog-post.txt?raw";
-import { logEvent, logError } from './utils/logger';
+import { initLogger, logEvent, logError } from './utils/logger';
 
 function slugify(text: string) {
   return text.toLowerCase().replace(/\s+/g, "-").replace(/[^a-z0-9-]/g, "");
@@ -15,6 +16,7 @@ function slugify(text: string) {
 
 export default {
   async scheduled(event: ScheduledEvent, env: Env, ctx: ExecutionContext) {
+    initLogger(env.pseudointelekt_logs, ctx);
     logEvent({ type: 'cron-start', time: event.scheduledTime });
     const date = new Date(event.scheduledTime).toISOString().split("T")[0];
 

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,3 +1,20 @@
+let logsKv: KVNamespace | undefined;
+let execCtx: ExecutionContext | undefined;
+
+export function initLogger(kv?: KVNamespace, ctx?: ExecutionContext): void {
+  logsKv = kv;
+  execCtx = ctx;
+}
+
+function storeLog(entry: Record<string, unknown>): void {
+  if (!logsKv) return;
+  const key = `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+  const promise = logsKv.put(key, JSON.stringify(entry));
+  if (execCtx) {
+    execCtx.waitUntil(promise);
+  }
+}
+
 export function logRequest(request: Request): void {
   const url = new URL(request.url);
   const headers = request.headers;
@@ -8,37 +25,37 @@ export function logRequest(request: Request): void {
   const ua = headers.get('User-Agent') || 'unknown';
   const referer = headers.get('Referer') || '';
   const host = headers.get('Host') || url.hostname;
-  console.log(
-    JSON.stringify({
-      time: new Date().toISOString(),
-      type: 'request',
-      method: request.method,
-      path: url.pathname + url.search,
-      host,
-      ip,
-      userAgent: ua,
-      referer,
-    })
-  );
+  const entry = {
+    time: new Date().toISOString(),
+    type: 'request',
+    method: request.method,
+    path: url.pathname + url.search,
+    host,
+    ip,
+    userAgent: ua,
+    referer,
+  };
+  console.log(JSON.stringify(entry));
+  storeLog(entry);
 }
 
 export function logEvent(event: Record<string, unknown>): void {
-  console.log(
-    JSON.stringify({
-      time: new Date().toISOString(),
-      ...event,
-    })
-  );
+  const entry = {
+    time: new Date().toISOString(),
+    ...event,
+  };
+  console.log(JSON.stringify(entry));
+  storeLog(entry);
 }
 
 export function logError(error: unknown, context: Record<string, unknown> = {}): void {
-  console.error(
-    JSON.stringify({
-      time: new Date().toISOString(),
-      type: 'error',
-      error: error instanceof Error ? error.message : String(error),
-      stack: error instanceof Error ? error.stack : undefined,
-      ...context,
-    })
-  );
+  const entry = {
+    time: new Date().toISOString(),
+    type: 'error',
+    error: error instanceof Error ? error.message : String(error),
+    stack: error instanceof Error ? error.stack : undefined,
+    ...context,
+  };
+  console.error(JSON.stringify(entry));
+  storeLog(entry);
 }

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -5,7 +5,7 @@ import { generateHeroImage } from './modules/heroImageGenerator';
 import { publishArticleToGitHub } from './modules/githubPublisher';
 import articlePrompt from './prompt/article-content.txt?raw';
 import heroTemplate from './prompt/hero-image.txt?raw';
-import { logRequest, logEvent, logError } from './utils/logger';
+import { initLogger, logRequest, logEvent, logError } from './utils/logger';
 
 async function handleContact(request: Request, env: Env) {
   logEvent({ type: 'contact-start' });
@@ -148,6 +148,7 @@ async function handleGetLikes(env: Env, slugs: string[] = []) {
 
 export default {
   async fetch(request: Request, env: Env, ctx: ExecutionContext) {
+    initLogger(env.pseudointelekt_logs, ctx);
     logRequest(request);
     const url = new URL(request.url);
     try {

--- a/worker-configuration.d.ts
+++ b/worker-configuration.d.ts
@@ -9,4 +9,5 @@ interface Env {
         pseudointelekt_contact_form: KVNamespace;
         pseudointelekt_views: KVNamespace;
         pseudointelekt_likes: KVNamespace;
+        pseudointelekt_logs: KVNamespace;
 }

--- a/wrangler.json
+++ b/wrangler.json
@@ -23,6 +23,11 @@
       "id": "e22b4da9fe0e45d8ae2515792d5929df",
       "preview_id": "e22b4da9fe0e45d8ae2515792d5929df"
     }
+    ,{
+      "binding": "pseudointelekt_logs",
+      "id": "d3a2f2838cff46bdaa9a9ef0e7bf1da9",
+      "preview_id": "d3a2f2838cff46bdaa9a9ef0e7bf1da9"
+    }
   ],
   "observability": {
     "enabled": true


### PR DESCRIPTION
## Summary
- augment Env with a `pseudointelekt_logs` namespace
- persist log messages to KV via `initLogger`
- configure worker and cron to initialise the logger
- add KV binding in `wrangler.json`
- set actual Cloudflare KV id `d3a2f2838cff46bdaa9a9ef0e7bf1da9`

## Testing
- `npm run build`
- `npx tsc`
- `npx wrangler deploy --dry-run`


------
https://chatgpt.com/codex/tasks/task_e_687384b7a300832c89659d80a3c13ce4