### PR TITLE
Add user session logging

### DIFF
--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -19,7 +19,7 @@ function storeLog(entry: Record<string, unknown>): void {
   }
 }
 
-export function logRequest(request: Request): void {
+export function logRequest(request: Request, sessionId?: string): void {
   const url = new URL(request.url);
   const headers = request.headers;
   const ip =
@@ -41,6 +41,7 @@ export function logRequest(request: Request): void {
     country,
     userAgent: ua,
     referer,
+    sessionId,
   };
   console.log(JSON.stringify(entry));
   storeLog(entry);

--- a/src/utils/session.ts
+++ b/src/utils/session.ts
@@ -1,0 +1,18 @@
+export interface SessionInfo {
+  id: string;
+  isNew: boolean;
+}
+
+export function getSessionInfo(request: Request): SessionInfo {
+  const cookie = request.headers.get('Cookie') || '';
+  const match = cookie.match(/(?:^|;\s*)sid=([^;]+)/);
+  if (match) {
+    return { id: match[1], isNew: false };
+  }
+  return { id: crypto.randomUUID(), isNew: true };
+}
+
+export function appendSessionCookie(response: Response, sessionId: string): void {
+  const cookie = `sid=${sessionId}; Path=/; HttpOnly; SameSite=Lax`;
+  response.headers.append('Set-Cookie', cookie);
+}


### PR DESCRIPTION
## Summary
- add session utilities for generating session IDs and cookies
- include `sessionId` in request logs
- manage session cookies and log session start events in the worker

## Testing
- `npm run build`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68738d11515c832cbff071ca1504b0e6