### PR TITLE
Switch logs from KV to D1

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,13 +89,23 @@ Wejście na ten adres uruchamia proces tworzenia wpisu i zwraca w odpowiedzi JSO
 
 ## Logowanie zdarzeń
 
-Worker zapisuje logi w przestrzeni **pseudointelekt_logs**. Każdy wpis to pojedynczy obiekt JSON, którego klucz ma postać:
+Logi są teraz zapisywane w bazie **D1** o nazwie `pseudointelekt_logs`. Tabela `logs` posiada kolumny:
 
-```
-YYYY-MM-DD/<typ>/<timestamp>-<losowe>
+- `id` – automatyczny identyfikator,
+- `time` – czas zdarzenia,
+- `worker_id` – identyfikator workera,
+- `data` – pełny zapis zdarzenia w formacie JSON.
+
+Aby utworzyć bazę wykonaj:
+
+```bash
+wrangler d1 create pseudointelekt_logs
 ```
 
-Przykładowy rekord dla zapytania HTTP wygląda następująco:
+Otrzymany `database_id` wpisz w pliku `wrangler.json` w sekcji `d1_databases` (w tym repo to `c290edf1-394f-4c8b-940c-da62db2774b1`).
+W sekcji `vars` ustaw `WORKER_ID` na `pseudointelekt2137-blog`, który będzie wstawiany do kolumny `worker_id`.
+
+Przykładowe zapytanie HTTP zostanie zapisane w kolumnie `data` jako JSON podobny do poniższego:
 
 ```json
 {
@@ -110,5 +120,3 @@ Przykładowy rekord dla zapytania HTTP wygląda następująco:
   "referer": "https://google.com"
 }
 ```
-
-Dzięki temu można łatwo filtrować logi po dacie i rodzaju zdarzenia.

--- a/src/cron-worker.ts
+++ b/src/cron-worker.ts
@@ -4,7 +4,8 @@ export interface Env {
   GITHUB_REPO: string; // owner/repo
   SLACK_WEBHOOK_URL: string;
   pseudointelekt_contact_form: KVNamespace;
-  pseudointelekt_logs: KVNamespace;
+  pseudointelekt_logs_db: D1Database;
+  WORKER_ID: string;
 }
 
 import blogPostPrompt from "./prompt/blog-post.txt?raw";
@@ -16,7 +17,7 @@ function slugify(text: string) {
 
 export default {
   async scheduled(event: ScheduledEvent, env: Env, ctx: ExecutionContext) {
-    initLogger(env.pseudointelekt_logs, ctx);
+    initLogger(env.pseudointelekt_logs_db, ctx, env.WORKER_ID);
     logEvent({ type: 'cron-start', time: event.scheduledTime });
     const date = new Date(event.scheduledTime).toISOString().split("T")[0];
 

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -159,7 +159,7 @@ async function handleGetLikes(env: Env, slugs: string[] = []) {
 
 export default {
   async fetch(request: Request, env: Env, ctx: ExecutionContext) {
-    initLogger(env.pseudointelekt_logs, ctx);
+    initLogger(env.pseudointelekt_logs_db, ctx, env.WORKER_ID);
     const session = getSessionInfo(request);
     logRequest(request, session.id);
     if (session.isNew) {

--- a/worker-configuration.d.ts
+++ b/worker-configuration.d.ts
@@ -9,5 +9,6 @@ interface Env {
         pseudointelekt_contact_form: KVNamespace;
         pseudointelekt_views: KVNamespace;
         pseudointelekt_likes: KVNamespace;
-        pseudointelekt_logs: KVNamespace;
+        WORKER_ID: string;
+        pseudointelekt_logs_db: D1Database;
 }

--- a/wrangler.json
+++ b/wrangler.json
@@ -23,12 +23,17 @@
       "id": "e22b4da9fe0e45d8ae2515792d5929df",
       "preview_id": "e22b4da9fe0e45d8ae2515792d5929df"
     }
-    ,{
-      "binding": "pseudointelekt_logs",
-      "id": "d3a2f2838cff46bdaa9a9ef0e7bf1da9",
-      "preview_id": "d3a2f2838cff46bdaa9a9ef0e7bf1da9"
+  ],
+  "d1_databases": [
+    {
+      "binding": "pseudointelekt_logs_db",
+      "database_name": "pseudointelekt_logs",
+      "database_id": "c290edf1-394f-4c8b-940c-da62db2774b1"
     }
   ],
+  "vars": {
+    "WORKER_ID": "pseudointelekt2137-blog"
+  },
   "observability": {
     "enabled": true
   },


### PR DESCRIPTION
## Summary
- store logs in D1 database instead of KV
- expose WORKER_ID and database binding in env
- update worker and cron code to use new logger
- document how to create the database
- fill config with worker ID pseudointelekt2137-blog and database_id c290edf1-394f-4c8b-940c-da62db2774b1

## Testing
- `npm run build`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68738f895028832ca6920c12f82df0b2