### PR TITLE
Trim request logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,13 +110,10 @@ Przykładowe zapytanie HTTP zostanie zapisane w kolumnie `data` jako JSON podobn
 ```json
 {
   "time": "2024-05-06T12:34:56.000Z",
-  "type": "request",
   "method": "GET",
   "path": "/about",
-  "host": "example.com",
   "ip": "203.0.113.42",
   "country": "PL",
-  "userAgent": "Mozilla/5.0",
   "referer": "https://google.com"
 }
 ```

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -39,18 +39,13 @@ export function logRequest(request: Request, sessionId?: string): void {
     'unknown';
   const cf = (request as any).cf || {};
   const country = cf.country || headers.get('CF-IPCountry') || 'unknown';
-  const ua = headers.get('User-Agent') || 'unknown';
   const referer = headers.get('Referer') || '';
-  const host = headers.get('Host') || url.hostname;
   const entry = {
     time: new Date().toISOString(),
-    type: 'request',
     method: request.method,
     path: url.pathname + url.search,
-    host,
     ip,
     country,
-    userAgent: ua,
     referer,
     sessionId,
   };


### PR DESCRIPTION
## Summary
- remove `host`, `userAgent` and the `type` field from request logs
- update README example to match new log format

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_68739672c45c832cad38fdc773821826