### PR TITLE
Set Polish locale for dates

### DIFF
--- a/src/components/FormattedDate.astro
+++ b/src/components/FormattedDate.astro
@@ -8,10 +8,10 @@ const { date } = Astro.props;
 
 <time datetime={date.toISOString()}>
 	{
-		date.toLocaleDateString('en-us', {
-			year: 'numeric',
-			month: 'short',
-			day: 'numeric',
-		})
+                date.toLocaleDateString('pl-PL', {
+                        year: 'numeric',
+                        month: 'short',
+                        day: 'numeric',
+                })
 	}
 </time>


### PR DESCRIPTION
## Summary
- switch to Polish locale in date formatting component

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687399529e40832ca9d52fc70ba74179