### PR TITLE
Add loading page for generate-article endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Możliwe jest też wygenerowanie wpisu poprzez endpoint Workers:
 GET /api/generate-article
 ```
 
-Wejście na ten adres uruchamia proces tworzenia wpisu i zwraca w odpowiedzi JSON z tytułem oraz treścią artykułu. Wygenerowane pliki są od razu commitowane do `main` na GitHubie.
+Domyślnie w przeglądarce pojawi się strona z komunikatem „Trwa generowanie artykułu” wraz z logami postępu. Po zakończeniu nastąpi przekierowanie na nowo utworzony wpis. Jeśli potrzebny jest surowy JSON z wynikiem, należy wysłać zapytanie z nagłówkiem `Accept: application/json`.
 
 ## Logowanie zdarzeń
 

--- a/src/utils/escapeHtml.ts
+++ b/src/utils/escapeHtml.ts
@@ -1,0 +1,18 @@
+export function escapeHtml(text: string): string {
+  return text.replace(/[&<>"']/g, (c) => {
+    switch (c) {
+      case '&':
+        return '&amp;';
+      case '<':
+        return '&lt;';
+      case '>':
+        return '&gt;';
+      case '"':
+        return '&quot;';
+      case "'":
+        return '&#39;';
+      default:
+        return c;
+    }
+  });
+}


### PR DESCRIPTION
## Summary
- show a loading page with live logs when using `/api/generate-article`
- keep JSON output when `Accept: application/json` is sent
- update docs for the new behaviour

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_68739a4dc2a0832c8eebbf01acd989a9