### PR TITLE
Add more logging for GitHub repo fetch

### DIFF
--- a/src/cron-worker.ts
+++ b/src/cron-worker.ts
@@ -59,13 +59,14 @@ export default {
       "Content-Type": "application/json",
     };
 
+    logEvent({ type: 'cron-github-repo-url', url: repoUrl });
     const repoRes = await fetch(repoUrl, { headers });
-    logEvent({ type: 'cron-github-repo-status', status: repoRes.status });
+    const repoText = await repoRes.text();
+    logEvent({ type: 'cron-github-repo-status', status: repoRes.status, body: repoText });
     if (!repoRes.ok) {
-      const msg = await repoRes.text();
-      throw new Error(`GitHub repo request failed: ${repoRes.status} ${msg}`);
+      throw new Error(`GitHub repo request failed: ${repoRes.status} ${repoText}`);
     }
-    const repo: any = await repoRes.json();
+    const repo: any = JSON.parse(repoText);
     const refRes = await fetch(
       `${repoUrl}/git/ref/heads/${repo.default_branch}`,
       { headers }


### PR DESCRIPTION
## Summary
- log GitHub repo URL and response body when fetching repo

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68739dc09d44832c971ca34f214aa391