### PR TITLE
Improve GitHub repo handling

### DIFF
--- a/src/cron-worker.ts
+++ b/src/cron-worker.ts
@@ -10,6 +10,7 @@ export interface Env {
 
 import blogPostPrompt from "./prompt/blog-post.txt?raw";
 import { initLogger, logEvent, logError } from './utils/logger';
+import { normalizeRepo } from './utils/github';
 
 function slugify(text: string) {
   return text.toLowerCase().replace(/\s+/g, "-").replace(/[^a-z0-9-]/g, "");
@@ -52,7 +53,14 @@ export default {
     const slug = slugify(title);
     const path = `src/content/blog/${date}-${slug}.md`;
 
-    const repoUrl = `https://api.github.com/repos/${env.GITHUB_REPO}`;
+    if (!env.GITHUB_TOKEN) {
+      throw new Error('GITHUB_TOKEN is not set');
+    }
+    if (!env.GITHUB_REPO) {
+      throw new Error('GITHUB_REPO is not set');
+    }
+    const repoPath = normalizeRepo(env.GITHUB_REPO);
+    const repoUrl = `https://api.github.com/repos/${repoPath}`;
     const headers = {
       Authorization: `Bearer ${env.GITHUB_TOKEN}`,
       "User-Agent": "cron-worker",

--- a/src/modules/githubPublisher.ts
+++ b/src/modules/githubPublisher.ts
@@ -1,6 +1,7 @@
 import { slugify } from '../utils/slugify';
 import { logEvent, logError } from '../utils/logger';
 import { retryFetch } from '../utils/retryFetch';
+import { normalizeRepo } from '../utils/github';
 import type { ArticleResult } from './articleGenerator';
 
 export interface PublishOptions {
@@ -14,7 +15,14 @@ export async function publishArticleToGitHub({ env, article, heroImage, date }: 
   logEvent({ type: 'github-publish-start', title: article.title });
   const postDate = date || new Date().toISOString().split('T')[0];
   const slug = slugify(article.title);
-  const repoUrl = `https://api.github.com/repos/${env.GITHUB_REPO}`;
+  if (!env.GITHUB_TOKEN) {
+    throw new Error('GITHUB_TOKEN is not set');
+  }
+  if (!env.GITHUB_REPO) {
+    throw new Error('GITHUB_REPO is not set');
+  }
+  const repoPath = normalizeRepo(env.GITHUB_REPO);
+  const repoUrl = `https://api.github.com/repos/${repoPath}`;
   const headers = {
     Authorization: `Bearer ${env.GITHUB_TOKEN}`,
     'User-Agent': 'article-publisher',

--- a/src/utils/github.ts
+++ b/src/utils/github.ts
@@ -1,0 +1,20 @@
+export function normalizeRepo(repo: string): string {
+  if (!repo) return repo;
+  repo = repo.trim().replace(/\.git$/, '');
+  if (repo.startsWith('http://') || repo.startsWith('https://')) {
+    try {
+      const url = new URL(repo);
+      if (url.hostname.endsWith('github.com')) {
+        const parts = url.pathname.replace(/^\//, '').split('/');
+        if (parts.length >= 2) {
+          return `${parts[0]}/${parts[1]}`;
+        }
+      }
+    } catch {
+      // fall through
+    }
+  } else if (repo.startsWith('git@github.com:')) {
+    repo = repo.substring('git@github.com:'.length);
+  }
+  return repo;
+}


### PR DESCRIPTION
## Summary
- handle GitHub repo strings that include URLs
- validate required env variables before using them

## Testing
- `npm run build`
- `npx tsc`
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_6873ae432114832c90980d5630d6abaa