### PR TITLE
Enhance prompts with history and length

### DIFF
--- a/scripts/publish-article.ts
+++ b/scripts/publish-article.ts
@@ -2,20 +2,29 @@ import { generateArticle } from '../src/modules/articleGenerator';
 import { generateHeroImage } from '../src/modules/heroImageGenerator';
 import { assembleArticle } from '../src/modules/articleAssembler';
 import { logEvent, logError } from '../src/utils/logger';
+import { getRecentTitlesFS } from '../src/utils/recentTitlesFs';
 import fs from 'node:fs/promises';
 import { execSync } from 'node:child_process';
 
 async function main() {
   logEvent({ type: 'cli-start' });
-  const articlePrompt = await fs.readFile('src/prompt/article-content.txt', 'utf8');
+  const articleTemplate = await fs.readFile('src/prompt/article-content.txt', 'utf8');
   const heroPromptTemplate = await fs.readFile('src/prompt/hero-image.txt', 'utf8');
+
+  const recent = await getRecentTitlesFS();
+  const recentList = recent.map((t, i) => `${i + 1}. ${t}`).join('\n');
+  const articlePrompt = articleTemplate.replace('{recent_titles}', recentList);
 
   const apiKey = process.env.OPENAI_API_KEY || '';
   if (!apiKey) {
     throw new Error('OPENAI_API_KEY is required');
   }
 
-  const article = await generateArticle({ apiKey, prompt: articlePrompt });
+  const article = await generateArticle({
+    apiKey,
+    prompt: articlePrompt,
+    maxTokens: 7200,
+  });
   const heroPrompt = heroPromptTemplate.replace('{title}', article.title);
   const heroImage = await generateHeroImage({ apiKey, prompt: heroPrompt });
 

--- a/src/modules/articleGenerator.ts
+++ b/src/modules/articleGenerator.ts
@@ -10,9 +10,10 @@ export interface ArticleResult {
 export interface GenerateArticleOptions {
   apiKey: string;
   prompt: string;
+  maxTokens?: number;
 }
 
-export async function generateArticle({ apiKey, prompt }: GenerateArticleOptions): Promise<ArticleResult> {
+export async function generateArticle({ apiKey, prompt, maxTokens }: GenerateArticleOptions): Promise<ArticleResult> {
   logEvent({ type: 'generate-article-start' });
   logEvent({
     type: 'openai-request',
@@ -28,6 +29,7 @@ export async function generateArticle({ apiKey, prompt }: GenerateArticleOptions
       },
       body: JSON.stringify({
         model: 'gpt-4o',
+        max_tokens: maxTokens,
         messages: [{ role: 'user', content: prompt }],
       }),
       retries: 2,

--- a/src/prompt/article-content.txt
+++ b/src/prompt/article-content.txt
@@ -1,1 +1,7 @@
-Napisz ironiczny artykuł na blog geopolityczny w formacie JSON zawierającym pola "title", "description" i "content". Używaj lekkiego języka i wpleć ciekawostki z bieżącej polityki. Zwróć tylko JSON bez dodatkowych komentarzy.
+Napisz ironiczny artykuł na blog geopolityczny w formacie JSON zawierającym pola "title", "description" i "content".
+Oto tytuły pięciu ostatnich wpisów:
+{recent_titles}
+Unikaj powtarzania tych tematów i skup się na nieco innym aspekcie.
+Używaj lekkiego języka i wpleć ciekawostki z bieżącej polityki.
+Tekst powinien być około dwukrotnie dłuższy niż zwykle.
+Zwróć tylko JSON bez dodatkowych komentarzy.

--- a/src/prompt/blog-post.txt
+++ b/src/prompt/blog-post.txt
@@ -1,7 +1,7 @@
 {
   "model": "gpt-4o",
   "temperature": 0.9,
-  "max_tokens": 3600,
+  "max_tokens": 7200,
   "messages": [
     {
       "role": "system",
@@ -9,7 +9,7 @@
     },
     {
       "role": "user",
-      "content": "Napisz artykuł blogowy o tym, jak Unia Europejska próbuje grać geopolitycznego twardziela wobec Chin, ale w praktyce przypomina bardziej wujka na weselu, który mówi: 'ja im zaraz powiem co myślę!', po czym wraca do stołu i zjada galaretę. Użyj ironii, odniesień kulturowych i lekko memicznego języka. Wpleć też kilka merytorycznych informacji o polityce handlowej, zależności od importu i inwestycjach chińskich w Europie."
+      "content": "Napisz artykuł blogowy o tym, jak Unia Europejska próbuje grać geopolitycznego twardziela wobec Chin, ale w praktyce przypomina bardziej wujka na weselu, który mówi: 'ja im zaraz powiem co myślę!', po czym wraca do stołu i zjada galaretę. Użyj ironii, odniesień kulturowych i lekko memicznego języka. Wpleć też kilka merytorycznych informacji o polityce handlowej, zależności od importu i inwestycjach chińskich w Europie. Dodaj nowe wątki, inne niż w ostatnich wpisach: {recent_titles}."
     }
   ]
 }

--- a/src/utils/recentTitlesFs.ts
+++ b/src/utils/recentTitlesFs.ts
@@ -1,0 +1,23 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+export async function getRecentTitlesFS(blogDir = 'src/content/blog', count = 5): Promise<string[]> {
+  const files = (await fs.readdir(blogDir))
+    .filter((f) => f.endsWith('.md') || f.endsWith('.mdx'))
+    .sort()
+    .reverse()
+    .slice(0, count);
+  const titles: string[] = [];
+  for (const file of files) {
+    try {
+      const text = await fs.readFile(path.join(blogDir, file), 'utf8');
+      const match = text.match(/title:\s*"?([^"\n]+)"?/);
+      if (match) {
+        titles.push(match[1].trim());
+      }
+    } catch {
+      // ignore
+    }
+  }
+  return titles;
+}

--- a/src/utils/recentTitlesGitHub.ts
+++ b/src/utils/recentTitlesGitHub.ts
@@ -1,0 +1,28 @@
+export async function getRecentTitlesFromGitHub(repo: string, token: string, count = 5): Promise<string[]> {
+  const url = `https://api.github.com/repos/${repo}/contents/src/content/blog`;
+  const res = await fetch(url, { headers: { Authorization: `Bearer ${token}` } });
+  if (!res.ok) {
+    throw new Error(`GitHub list request failed: ${res.status}`);
+  }
+  const list: any[] = await res.json();
+  const files = list
+    .filter((f) => (f.name.endsWith('.md') || f.name.endsWith('.mdx')) && f.type === 'file')
+    .map((f) => f.name)
+    .sort()
+    .reverse()
+    .slice(0, count);
+  const titles: string[] = [];
+  for (const name of files) {
+    const fileRes = await fetch(`${url}/${encodeURIComponent(name)}`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    if (!fileRes.ok) continue;
+    const data: any = await fileRes.json();
+    const content = Buffer.from(data.content, 'base64').toString('utf8');
+    const match = content.match(/title:\s*"?([^"\n]+)"?/);
+    if (match) {
+      titles.push(match[1].trim());
+    }
+  }
+  return titles;
+}

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -3,8 +3,9 @@ import cron from './cron-worker';
 import { generateArticle } from './modules/articleGenerator';
 import { generateHeroImage } from './modules/heroImageGenerator';
 import { publishArticleToGitHub } from './modules/githubPublisher';
-import articlePrompt from './prompt/article-content.txt?raw';
+import articleTemplate from './prompt/article-content.txt?raw';
 import heroTemplate from './prompt/hero-image.txt?raw';
+import { getRecentTitlesFromGitHub } from './utils/recentTitlesGitHub';
 import { initLogger, logRequest, logEvent, logError } from './utils/logger';
 import { getSessionInfo, appendSessionCookie } from './utils/session';
 import { slugify } from './utils/slugify';
@@ -48,7 +49,14 @@ async function handleContact(request: Request, env: Env) {
 }
 
 async function generateAndPublish(env: Env) {
-  const article = await generateArticle({ apiKey: env.OPENAI_API_KEY, prompt: articlePrompt });
+  const recent = await getRecentTitlesFromGitHub(env.GITHUB_REPO, env.GITHUB_TOKEN);
+  const recentList = recent.map((t, i) => `${i + 1}. ${t}`).join('\n');
+  const articlePrompt = articleTemplate.replace('{recent_titles}', recentList);
+  const article = await generateArticle({
+    apiKey: env.OPENAI_API_KEY,
+    prompt: articlePrompt,
+    maxTokens: 7200,
+  });
   const heroPrompt = heroTemplate.replace('{title}', article.title);
   const heroImage = await generateHeroImage({ apiKey: env.OPENAI_API_KEY, prompt: heroPrompt });
   await publishArticleToGitHub({ env, article, heroImage });


### PR DESCRIPTION
## Summary
- extend article generation module to accept `maxTokens`
- include last five article titles when generating content
- bump token count for blog posts
- add GitHub and filesystem utilities for fetching recent titles
- update worker, cron worker and CLI to use the new prompts

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6873af875904832ca315939f1f4891dd