### PR TITLE
Return JSON error response

### DIFF
--- a/src/worker.ts
+++ b/src/worker.ts
@@ -297,7 +297,14 @@ export default {
       return response;
     } catch (err) {
       logError(err, { type: 'fetch-error', path: url.pathname });
-      throw err;
+      const errorResponse = {
+        message: err instanceof Error ? err.message : String(err),
+        stack: err instanceof Error ? err.stack : undefined,
+      };
+      return new Response(JSON.stringify(errorResponse, null, 2), {
+        status: 500,
+        headers: { 'Content-Type': 'application/json' },
+      });
     }
   },
   scheduled: cron.scheduled,


### PR DESCRIPTION
## Summary
- update worker fetch catch block to return JSON error message instead of throwing

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_6873c5eefd6c832cbc5e64a670fac2e1