### PR TITLE
Fix GitHub upload for Unicode posts

### DIFF
--- a/src/modules/githubPublisher.ts
+++ b/src/modules/githubPublisher.ts
@@ -87,7 +87,7 @@ export async function publishArticleToGitHub({ env, article, heroImage, date }: 
       headers,
       body: JSON.stringify({
         message: `Add post for ${postDate}`,
-        content: btoa(markdown),
+        content: Buffer.from(markdown, 'utf-8').toString('base64'),
         branch,
       }),
       retries: 2,


### PR DESCRIPTION
## Summary
- update GitHub publisher to use Buffer for base64 encoding

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_6873da9fec5c832cb9a0603ad6c86099