### PR TITLE
Add Slack notification with PR link after article generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,9 +83,14 @@ Wygenerowane wpisy są automatycznie publikowane na gałęzi `main` w repozytori
 
 Możliwe jest też wygenerowanie wpisu poprzez endpoint Workers:
 
+
 ```
 GET /api/generate-article
 ```
+
+Po każdej publikacji Worker wysyła powiadomienie na Slacka zawierające
+początek artykułu oraz link do utworzonego pull requesta na GitHubie.
+Pozwala to szybko zaakceptować zmiany.
 
 Domyślnie w przeglądarce pojawi się strona z komunikatem „Trwa generowanie artykułu” wraz z logami postępu. Po zakończeniu nastąpi przekierowanie na nowo utworzony wpis. Jeśli potrzebny jest surowy JSON z wynikiem, należy wysłać zapytanie z nagłówkiem `Accept: application/json`.
 

--- a/src/modules/generateAndPublish.ts
+++ b/src/modules/generateAndPublish.ts
@@ -1,5 +1,6 @@
 import { generateArticleAssets } from './generateArticleAssets';
 import { publishArticleToGitHub } from './githubPublisher';
+import { sendSlackMessage } from '../utils/slack';
 import articleTemplate from '../prompt/article-content.txt?raw';
 import heroTemplate from '../prompt/hero-image.txt?raw';
 import { getRecentTitlesFromGitHub } from '../utils/recentTitlesGitHub';
@@ -20,6 +21,11 @@ export async function generateAndPublish(env: Env): Promise<GenerateAndPublishRe
     recentTitles: recent,
     maxTokens: 7200,
   });
-  await publishArticleToGitHub({ env, article, heroImage });
+  const prUrl = await publishArticleToGitHub({ env, article, heroImage });
+  const snippet = article.content.slice(0, 300);
+  await sendSlackMessage(
+    env.SLACK_WEBHOOK_URL,
+    `Nowy artykuł: ${article.title}\n${snippet}...\n${prUrl}`
+  );
   return { article, slug: slugify(article.title) };
 }

--- a/src/utils/slack.ts
+++ b/src/utils/slack.ts
@@ -1,0 +1,23 @@
+import { retryFetch } from './retryFetch';
+import { logEvent, logError } from './logger';
+
+export async function sendSlackMessage(webhook: string, text: string): Promise<void> {
+  logEvent({ type: 'slack-send-start' });
+  try {
+    const res = await retryFetch(webhook, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ text }),
+      retries: 2,
+      retryDelayMs: 1000,
+    });
+    logEvent({ type: 'slack-send-status', status: res.status });
+    if (!res.ok) {
+      const msg = await res.text();
+      throw new Error(`Slack webhook failed: ${res.status} ${msg}`);
+    }
+    logEvent({ type: 'slack-send-complete' });
+  } catch (err) {
+    logError(err, { type: 'slack-send-error' });
+  }
+}


### PR DESCRIPTION
## Summary
- notify Slack after generating and publishing articles
- return PR URL from githubPublisher
- send article snippet and PR link in Slack alert
- mention Slack notifications in README

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_6873e3ff86ac832c8b5620345c4366c7