### PR TITLE
Fix arrow icons in post navigation

### DIFF
--- a/src/components/PostNavigation.astro
+++ b/src/components/PostNavigation.astro
@@ -10,14 +10,14 @@ const truncate = (title: string, len = 50) =>
 <nav class="post-nav">
     {prev && (
         <a href={`/blog/${prev.id}/`} class="prev">
-            <span class="arrow" aria-hidden="true">\u2190</span>
+            <span class="arrow" aria-hidden="true">←</span>
             <span class="title">{truncate(prev.data.title)}</span>
         </a>
     )}
     {next && (
         <a href={`/blog/${next.id}/`} class="next">
             <span class="title">{truncate(next.data.title)}</span>
-            <span class="arrow" aria-hidden="true">\u2192</span>
+            <span class="arrow" aria-hidden="true">→</span>
         </a>
     )}
 </nav>
@@ -28,7 +28,7 @@ const truncate = (title: string, len = 50) =>
     gap: 1em;
     margin: 2em 0;
     padding: 0 1em;
-    flex-wrap: wrap;
+    flex-wrap: nowrap;
 }
 .post-nav a {
     color: var(--accent);


### PR DESCRIPTION
## Summary
- display real arrow icons instead of unicode escape codes in post navigation
- keep navigation links on one line by disabling flex wrapping

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6873e5fc8910832cbef4a4feb2317da7