### PR TITLE
Show generation details on SSE page

### DIFF
--- a/docs/generate-stream.md
+++ b/docs/generate-stream.md
@@ -8,7 +8,14 @@ Nowy mechanizm pozwala śledzić postęp tworzenia wpisu w czasie rzeczywistym z
 GET /api/generate-stream
 ```
 
-Odpowiedzią jest strumień `text/event-stream`. Każda wiadomość to obiekt JSON zawierający przynajmniej pole `log`. Po zakończeniu wysyłany jest obiekt `{ done: true, url: '<link do PR>' }`.
+Odpowiedzią jest strumień `text/event-stream`. Każda wiadomość to obiekt JSON zawierający przynajmniej pole `log`. Dodatkowe pola mogą przekazywać:
+
+- `recentTitles` – listę pobranych tytułów;
+- `articlePrompt` – finalny prompt wysłany do ChatGPT;
+- `articleTitle` – tytuł wygenerowanego artykułu;
+- `heroPrompt` – prompt użyty do stworzenia obrazka.
+
+Po zakończeniu wysyłany jest obiekt `{ done: true, url: '<link do PR>' }`.
 
 ## Podstrona `generuj.html`
 

--- a/public/generuj.html
+++ b/public/generuj.html
@@ -6,20 +6,51 @@
 <style>
 body { font-family: sans-serif; padding: 2rem; }
 #log { white-space: pre-wrap; background: #f4f4f4; padding: 1rem; border-radius: 4px; max-height: 60vh; overflow-y: auto; }
+#info { margin: 1em 0; }
+#info h2 { margin-top: 1em; }
+.home-button { display: inline-block; margin-top: 2em; padding: 0.75em 1.5em; background: var(--diplomatic-blue, #1c3d5a); color: var(--ivory, #f8f6f1); border-radius: 4px; text-decoration: none; border: 2px solid var(--diplomatic-blue, #1c3d5a); }
+.home-button:hover { background: var(--gold-accent, #cba135); color: var(--charcoal, #2d2d2d); }
 </style>
 </head>
 <body>
 <h1>Generowanie artykułu</h1>
 <div id="status">Oczekiwanie na dane...</div>
+<div id="info">
+  <h2>Ostatnie tytuły</h2>
+  <ul id="titles"></ul>
+  <h2>Nowy artykuł</h2>
+  <p id="article-title"></p>
+  <h2>Prompt (artykuł)</h2>
+  <pre id="article-prompt"></pre>
+  <h2>Prompt (obrazek)</h2>
+  <pre id="hero-prompt"></pre>
+</div>
 <pre id="log"></pre>
+<a href="/" class="home-button">Strona główna</a>
 <script>
 const logEl = document.getElementById('log');
 const statusEl = document.getElementById('status');
+const titlesEl = document.getElementById('titles');
+const articleTitleEl = document.getElementById('article-title');
+const articlePromptEl = document.getElementById('article-prompt');
+const heroPromptEl = document.getElementById('hero-prompt');
 const es = new EventSource('/api/generate-stream');
 es.onmessage = (e) => {
   const msg = JSON.parse(e.data);
   if (msg.log) {
     logEl.textContent += msg.log + '\n';
+  }
+  if (msg.recentTitles) {
+    titlesEl.innerHTML = msg.recentTitles.map(t => `<li>${t}</li>`).join('');
+  }
+  if (msg.articleTitle) {
+    articleTitleEl.textContent = msg.articleTitle;
+  }
+  if (msg.articlePrompt) {
+    articlePromptEl.textContent = msg.articlePrompt;
+  }
+  if (msg.heroPrompt) {
+    heroPromptEl.textContent = msg.heroPrompt;
   }
   if (msg.done) {
     statusEl.innerHTML = `Zakończono! <a href="${msg.url}">Zobacz PR</a>`;

--- a/src/modules/generateAndPublish.ts
+++ b/src/modules/generateAndPublish.ts
@@ -26,17 +26,24 @@ export async function generateAndPublish(
   try {
     send('🚀 Startujemy! Pobieram listę ostatnich tytułów z GitHuba...');
     const recent = await getRecentTitlesFromGitHub(env.GITHUB_REPO, env.GITHUB_TOKEN);
+    send('📑 Pobrane tytuły', { recentTitles: recent });
 
-    send('🧠 Generuję treść artykułu...');
+    const finalPrompt = articleTemplate.replace(
+      '{recent_titles}',
+      recent.map((t, i) => `${i + 1}. ${t}`).join('\n')
+    );
+
+    send('🧠 Generuję treść artykułu...', { articlePrompt: finalPrompt });
     const article = await generateArticle({
       apiKey: env.OPENAI_API_KEY,
       prompt: articleTemplate,
       recentTitles: recent,
       maxTokens: 7200,
     });
+    send(`✏️ Wygenerowano tytuł: ${article.title}`, { articleTitle: article.title });
 
-    send('🎨 Tworzę obrazek do artykułu...');
     const heroPrompt = heroTemplate.replace('{title}', article.title);
+    send('🎨 Tworzę obrazek do artykułu...', { heroPrompt });
     const heroImage = await generateHeroImage({ apiKey: env.OPENAI_API_KEY, prompt: heroPrompt });
 
     send('📦 Publikuję na GitHubie...');


### PR DESCRIPTION
## Summary
- include titles and prompts in SSE output from `generateAndPublish`
- display additional info on `generuj.html` with a home button
- document new SSE fields

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_6873f1e7ab6c832ca73b5a1660682aa0