### PR TITLE
Add custom prompt editing feature

### DIFF
--- a/docs/generate-stream.md
+++ b/docs/generate-stream.md
@@ -8,14 +8,20 @@ Nowy mechanizm pozwala śledzić postęp tworzenia wpisu w czasie rzeczywistym z
 GET /api/generate-stream
 ```
 
+Możesz opcjonalnie przekazać własny prompt w parametrze `prompt`:
+
+```
+GET /api/generate-stream?prompt=Twoj%20tekst
+```
+
 Odpowiedzią jest strumień `text/event-stream`. Każda wiadomość to obiekt JSON zawierający przynajmniej pole `log`. Po zakończeniu wysyłany jest obiekt `{ done: true, url: '<link do PR>' }`.
 
 ## Podstrona `generuj.html`
 
-W katalogu `public/` dodano prostą stronę, która łączy się z powyższym strumieniem i wypisuje wszystkie logi. Otwórz w przeglądarce `/generuj.html`, aby uruchomić proces i obserwować postęp.
+W katalogu `public/` znajduje się teraz strona pozwalająca edytować prompt przed startem generowania. Otwórz w przeglądarce `/generuj.html`, wpisz własny tekst i kliknij **Start**, aby obserwować postęp.
 
 ```
-const es = new EventSource('/api/generate-stream');
+const es = new EventSource('/api/generate-stream?prompt=' + encodeURIComponent('Twój prompt'));
 es.onmessage = (e) => {
   const msg = JSON.parse(e.data);
   // msg.log zawiera aktualny etap

--- a/public/generuj.html
+++ b/public/generuj.html
@@ -9,27 +9,45 @@ body { font-family: sans-serif; padding: 2rem; }
 </style>
 </head>
 <body>
-<h1>Generowanie artykułu</h1>
-<div id="status">Oczekiwanie na dane...</div>
-<pre id="log"></pre>
-<script>
-const logEl = document.getElementById('log');
-const statusEl = document.getElementById('status');
-const es = new EventSource('/api/generate-stream');
-es.onmessage = (e) => {
-  const msg = JSON.parse(e.data);
-  if (msg.log) {
-    logEl.textContent += msg.log + '\n';
+  <h1>Generowanie artykułu</h1>
+  <label for="prompt">Prompt:</label><br />
+  <textarea id="prompt" rows="10" cols="80">Napisz ironiczny artykuł na blog geopolityczny w formacie JSON zawierającym pola "title", "description" i "content".
+Oto tytuły pięciu ostatnich wpisów:
+{recent_titles}
+Unikaj powtarzania tych tematów i skup się na nieco innym aspekcie.
+Używaj lekkiego języka i wpleć ciekawostki z bieżącej polityki.
+Tekst powinien być około dwukrotnie dłuższy niż zwykle.
+Zwróć tylko JSON bez dodatkowych komentarzy.</textarea>
+  <br />
+  <button id="start">Start</button>
+  <div id="status"></div>
+  <pre id="log"></pre>
+  <script>
+  const logEl = document.getElementById('log');
+  const statusEl = document.getElementById('status');
+  const startBtn = document.getElementById('start');
+  let es;
+  function start() {
+    startBtn.disabled = true;
+    const prompt = document.getElementById('prompt').value;
+    statusEl.textContent = 'Łączę...';
+    es = new EventSource('/api/generate-stream?prompt=' + encodeURIComponent(prompt));
+    es.onmessage = (e) => {
+      const msg = JSON.parse(e.data);
+      if (msg.log) {
+        logEl.textContent += msg.log + '\n';
+      }
+      if (msg.done) {
+        statusEl.innerHTML = `Zakończono! <a href="${msg.url}">Zobacz PR</a>`;
+        es.close();
+      }
+    };
+    es.onerror = () => {
+      statusEl.textContent = 'Błąd połączenia';
+      es.close();
+    };
   }
-  if (msg.done) {
-    statusEl.innerHTML = `Zakończono! <a href="${msg.url}">Zobacz PR</a>`;
-    es.close();
-  }
-};
-es.onerror = () => {
-  statusEl.textContent = 'Błąd połączenia';
-  es.close();
-};
-</script>
+  startBtn.addEventListener('click', start);
+  </script>
 </body>
 </html>

--- a/src/modules/generateAndPublish.ts
+++ b/src/modules/generateAndPublish.ts
@@ -15,7 +15,8 @@ export interface GenerateAndPublishResult {
 
 export async function generateAndPublish(
   env: Env,
-  controller?: { enqueue: (chunk: string) => void; close: () => void }
+  controller?: { enqueue: (chunk: string) => void; close: () => void },
+  articlePrompt: string = articleTemplate
 ): Promise<GenerateAndPublishResult> {
   const send = (log: string, data: Record<string, unknown> = {}) => {
     if (!controller) return;
@@ -30,7 +31,7 @@ export async function generateAndPublish(
     send('🧠 Generuję treść artykułu...');
     const article = await generateArticle({
       apiKey: env.OPENAI_API_KEY,
-      prompt: articleTemplate,
+      prompt: articlePrompt,
       recentTitles: recent,
       maxTokens: 7200,
     });

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -178,7 +178,8 @@ export default {
           enqueue: (chunk: string) => writer.write(new TextEncoder().encode(chunk)),
           close: () => writer.close(),
         };
-        generateAndPublish(env, ctrl).catch(err => {
+        const prompt = url.searchParams.get('prompt') || undefined;
+        generateAndPublish(env, ctrl, prompt).catch(err => {
           console.error('Błąd w tle:', err);
           const msg = JSON.stringify({ log: `❌ KRYTYCZNY BŁĄD: ${err.message}` });
           ctrl.enqueue(`data: ${msg}\n\n`);


### PR DESCRIPTION
## Summary
- allow `generateAndPublish` to accept custom article prompt
- pass optional `prompt` query parameter in `/api/generate-stream`
- update `generuj.html` with prompt textarea and start button
- document new prompt parameter

## Testing
- `npm run build`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_6873f256b5b0832cb87c8b73dd37adcb