### PR TITLE
Add client log endpoint and page logging

### DIFF
--- a/docs/generate-stream.md
+++ b/docs/generate-stream.md
@@ -48,3 +48,6 @@ es.onmessage = (e) => {
 1. Uruchom lokalnie `npm run dev`.
 2. Otwórz `http://localhost:8787/generuj.html` (port zależy od konfiguracji wranglera).
 3. Obserwuj logi i poczekaj na link do pull requesta.
+
+Podstrona `generuj.html` przesyła teraz własne zdarzenia pod endpoint `POST /api/client-log`,
+dzięki czemu wszystkie akcje z przeglądarki trafiają do bazy D1.

--- a/public/generuj.html
+++ b/public/generuj.html
@@ -53,6 +53,16 @@ const prLinkEl = document.getElementById('pr-link');
 const continueBtn = document.getElementById('continue-btn');
 let promptShown = false;
 
+function sendLog(event, details = {}) {
+  fetch('/api/client-log', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ event, ...details }),
+    credentials: 'include',
+    keepalive: true,
+  }).catch(() => {});
+}
+
 startStream();
 
 function appendLog(text) {
@@ -68,12 +78,16 @@ function appendLogElement(el) {
 }
 
 function startStream() {
+  appendLog('🔗 Łączenie z /api/generate-stream...');
+  sendLog('connect', { endpoint: '/api/generate-stream' });
   const es = new EventSource('/api/generate-stream');
   es.addEventListener('open', () => {
     appendLog('🔌 Połączono z serwerem');
+    sendLog('sse-open');
   });
   es.onmessage = (e) => {
     const msg = JSON.parse(e.data);
+    sendLog('sse-message', msg);
     if (msg.log) {
       appendLog(msg.log);
     }
@@ -111,6 +125,7 @@ function startStream() {
       statusEl.textContent = 'Zakończono!';
       prLinkEl.href = msg.url;
       prLinkEl.style.display = 'inline-block';
+      sendLog('sse-complete', { url: msg.url });
       es.close();
     }
   };
@@ -118,13 +133,15 @@ function startStream() {
     statusEl.textContent = 'Błąd połączenia (SSE)';
     appendLog('❌ Błąd połączenia (SSE)');
     console.error('EventSource failed', err);
+    sendLog('sse-error', { message: err.message });
     es.close();
   };
 
   continueBtn.addEventListener('click', async () => {
     continueBtn.disabled = true;
     try {
-      appendLog('📨 Wysyłam zaktualizowany prompt...');
+      appendLog('📨 Wysyłam zaktualizowany prompt do /api/update-prompt...');
+      sendLog('update-prompt-send', { endpoint: '/api/update-prompt' });
       const res = await fetch('/api/update-prompt', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -132,11 +149,13 @@ function startStream() {
         credentials: 'include',
       });
       if (!res.ok) throw new Error('status ' + res.status);
+      sendLog('update-prompt-response', { status: res.status });
       appendLog('⏭ Kontynuuję tworzenie...');
       articlePromptEl.setAttribute('readonly', '');
       continueBtn.style.display = 'none';
     } catch (err) {
       appendLog(`❌ Błąd podczas wysyłania prompta: ${err}`);
+      sendLog('update-prompt-error', { message: String(err) });
       continueBtn.disabled = false;
     }
   });


### PR DESCRIPTION
## Summary
- log browser events in generuj.html to the D1 database
- implement `/api/client-log` endpoint in the worker
- mention the new endpoint in docs

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_6874109f68f4832c84a8fae372f55013