### PR TITLE
Fix SSE prompt wait time

### DIFF
--- a/src/modules/generateAndPublish.ts
+++ b/src/modules/generateAndPublish.ts
@@ -24,6 +24,10 @@ export async function generateAndPublish(
     controller.enqueue(`data: ${message}\n\n`);
   };
 
+  const keepAlive = setInterval(() => {
+    controller?.enqueue(':keepalive\n\n');
+  }, 20000);
+
   try {
     send('🚀 Startujemy! Pobieram listę ostatnich tytułów z GitHuba...');
     const recent = await getRecentTitlesFromGitHub(env.GITHUB_REPO, env.GITHUB_TOKEN);
@@ -75,6 +79,7 @@ export async function generateAndPublish(
     send(`❌ Błąd: ${(err as Error).message}`);
     throw err;
   } finally {
+    clearInterval(keepAlive);
     controller?.close();
   }
 }

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -209,14 +209,16 @@ export default {
         };
         const deferred = createDeferred<string>();
         pendingPrompts.set(session.id, deferred.resolve);
-        generateAndPublish(env, ctrl, deferred.promise)
-          .catch(err => {
-            console.error('Błąd w tle:', err);
-            const msg = JSON.stringify({ log: `❌ KRYTYCZNY BŁĄD: ${err.message}` });
-            ctrl.enqueue(`data: ${msg}\n\n`);
-            ctrl.close();
-          })
-          .finally(() => pendingPrompts.delete(session.id));
+        ctx.waitUntil(
+          generateAndPublish(env, ctrl, deferred.promise)
+            .catch(err => {
+              console.error('Błąd w tle:', err);
+              const msg = JSON.stringify({ log: `❌ KRYTYCZNY BŁĄD: ${err.message}` });
+              ctrl.enqueue(`data: ${msg}\n\n`);
+              ctrl.close();
+            })
+            .finally(() => pendingPrompts.delete(session.id))
+        );
         response = new Response(readable, {
           headers: {
             'Content-Type': 'text/event-stream',


### PR DESCRIPTION
## Summary
- keep the generate-stream connection alive with periodic heartbeats
- keep background task alive with `ctx.waitUntil`

## Testing
- `npm install`
- `npm run build`
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_6874140efb88832cbb09b5c990b1caea