### PR TITLE
Fix blog order

### DIFF
--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -7,9 +7,11 @@ import { getCollection } from 'astro:content';
 import FormattedDate from '../../components/FormattedDate.astro';
 import Sidebar from '../../components/Sidebar.astro';
 
-const posts = (await getCollection('blog')).sort(
-  (a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf(),
-);
+// Sort posts so the newest ones appear first on the blog index
+const posts = (await getCollection('blog')).sort((a, b) => {
+  const dateDiff = b.data.pubDate.valueOf() - a.data.pubDate.valueOf();
+  return dateDiff === 0 ? b.id.localeCompare(a.id) : dateDiff;
+});
 ---
 
 <!doctype html>


### PR DESCRIPTION
## Summary
- keep blog posts in reverse chronological order

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687426e465fc832c936b852d2e67931e