### PR TITLE
Add sitemap generator and SEO improvements

### DIFF
--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -2,6 +2,7 @@
 // Import the global.css file here so that it is included on
 // all pages through the use of the <BaseHead /> component.
 import '../styles/global.css';
+import { SITE_KEYWORDS } from '../consts';
 
 interface Props {
 	title: string;
@@ -32,6 +33,7 @@ const { title, description, image = '/blog-placeholder-1.jpg' } = Astro.props;
 <title>{title}</title>
 <meta name="title" content={title} />
 <meta name="description" content={description} />
+<meta name="keywords" content={SITE_KEYWORDS} />
 
 <!-- Open Graph / Facebook -->
 <meta property="og:type" content="website" />

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -5,3 +5,5 @@
 export const SITE_TITLE = "pseudointelekt.pl";
 export const SITE_DESCRIPTION = "Blog Pseudointelekt";
 export const CONTACT_EMAIL = "info@pseidointelekt.pl";
+export const SITE_KEYWORDS =
+  "geopolityka, blog, komentarz, humor, polityka";

--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -5,6 +5,7 @@ import Header from '../components/Header.astro';
 import Footer from '../components/Footer.astro';
 import FormattedDate from '../components/FormattedDate.astro';
 import PostNavigation from '../components/PostNavigation.astro';
+import { SITE_TITLE } from '../consts';
 
 type Props = CollectionEntry<'blog'>['data'] & {
     slug: string;
@@ -23,15 +24,30 @@ const {
     prev,
     next,
 } = Astro.props as Props;
+
+const jsonLd = {
+  "@context": "https://schema.org",
+  "@type": "BlogPosting",
+  headline: title,
+  description,
+  image: heroImage ? new URL(heroImage, Astro.site).toString() : undefined,
+  url: new URL(`/blog/${slug}/`, Astro.site).toString(),
+  datePublished: pubDate.toISOString(),
+  dateModified: (updatedDate ?? pubDate).toISOString(),
+  author: { "@type": "Organization", name: SITE_TITLE },
+};
 ---
 
 <html lang="en">
-	<head>
-		<BaseHead title={title} description={description} />
-		<style>
-			main {
-				width: calc(100% - 2em);
-				max-width: 100%;
+        <head>
+                <BaseHead title={title} description={description} />
+                <script type="application/ld+json">
+                        {JSON.stringify(jsonLd)}
+                </script>
+                <style>
+                        main {
+                                width: calc(100% - 2em);
+                                max-width: 100%;
 				margin: 0;
 			}
 			.hero-image {

--- a/src/pages/robots.txt.ts
+++ b/src/pages/robots.txt.ts
@@ -1,0 +1,10 @@
+export function GET() {
+  return new Response(
+    `User-agent: *\nAllow: /\nSitemap: https://pseudointelekt.pl/sitemap-index.xml`,
+    {
+      headers: {
+        'Content-Type': 'text/plain',
+      },
+    },
+  );
+}


### PR DESCRIPTION
## Summary
- define `SITE_KEYWORDS`
- add keywords meta tag
- embed JSON-LD structured data for blog posts
- expose `robots.txt` with sitemap reference

## Testing
- `npm install`
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_68874fe7f2e8832cbb23f846962264f3