### PR TITLE
Improve OpenAI response handling and logging

### DIFF
--- a/public/generuj.html
+++ b/public/generuj.html
@@ -89,6 +89,9 @@ function startStream() {
     if (msg.log) {
       appendLog(msg.log);
     }
+  if (msg.error) {
+    appendLog(`❌ Błąd: ${msg.error}`);
+  }
   if (msg.warnings) {
     appendLog('⚠️ Ostrzeżenia:');
     const list = document.createElement('ul');


### PR DESCRIPTION
## Summary
- Parse structured OpenAI chat responses and log debug info when content is missing
- Surface error messages on the article generator page for clearer feedback

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689c5d3e97b4832ca4fe0f296ed0756a