### PR TITLE
Improve OpenAI response handling and logging

### DIFF
--- a/docs/article-generation.md
+++ b/docs/article-generation.md
@@ -5,11 +5,11 @@ Ten projekt automatyzuje tworzenie satyrycznych wpisów na bloga. Poniżej opisa
 ## 1. Gorące tematy i wybór wątku
 1. Pobierz tytuły ostatnich artykułów z GitHuba.
 2. `getHotTopics()` zbiera wiadomości z RSS (BBC, Politico, PAP, Reuters). Lista jest wysyłana w logu SSE `🔥 Gorące tematy z ostatnich dni`.
-3. `suggestArticleTopic()` (max_completion_tokens 600) proponuje satyryczne tematy na podstawie gorących newsów i ostatnich wpisów. Użytkownik wybiera jedną z propozycji lub podaje własny temat bazowy.
+3. `suggestArticleTopic()` (max_completion_tokens 2000, `response_style=brief`) proponuje satyryczne tematy na podstawie gorących newsów i ostatnich wpisów. Użytkownik wybiera jedną z propozycji lub podaje własny temat bazowy.
 
 ## 2. Outline
 `generateOutline(baseTopic)` przygotowuje strukturę artykułu:
-- używa `chat()` (model gpt-5) z guardrails i `max_completion_tokens` 800,
+- używa `chat()` (model gpt-5) z guardrails, `max_completion_tokens` 800 i `response_style=normal`,
 - zwraca `finalTitle`, `description` i 4–5 sekcji po 2–5 bulletów,
 - każdy bullet zawiera konkretną statystykę, datę lub nazwę raportu z wiarygodnym źródłem; w razie braku danych oznaczony jest `[[TODO-CLAIM]]`,
 - opis ≤200 znaków, bez znaków markdown; tytuł ≤100 znaków,
@@ -17,19 +17,19 @@ Ten projekt automatyzuje tworzenie satyrycznych wpisów na bloga. Poniżej opisa
 
 ## 3. Draft
 `generateDraft(outline, articlePrompt)` tworzy szkic:
- - korzysta z `chat()` (model gpt-5, max_completion_tokens 1200) z wklejonym outline oraz regułami,
+ - korzysta z `chat()` (model gpt-5, max_completion_tokens 1200, `response_style=full`) z wklejonym outline oraz regułami,
  - każdy bullet rozwijany jest w spójny, profesjonalny akapit liczący około 12–20 linijek (≥10 zdań) z co najmniej jedną statystyką lub raportem wraz ze źródłem,
  - niepewne dane oznaczane są tokenem `[[TODO-CLAIM]]`.
 
 ## 4. Edit
 `editDraft(draft, outline)` wygładza tekst:
- - `chat()` (model gpt-5, max_completion_tokens 1000),
+ - `chat()` (model gpt-5, max_completion_tokens 1000, `response_style=full`),
  - nie zmienia tytułu ani opisu, dba o spójne akapity 12–20 linijek z rzetelnymi danymi i źródłami,
  - `scrubTodoClaims()` zastępuje zdania z `[[TODO-CLAIM]]` neutralnym uogólnieniem.
 
 ## 5. Proofread
 `proofread(edited)` sprawdza gramatykę, styl i płynność całego tekstu:
- - `chat()` (model gpt-5, max_completion_tokens 1000),
+ - `chat()` (model gpt-5, max_completion_tokens 1000, `response_style=full`),
 - usuwa powtórzenia i nienaturalnie brzmiące frazy, przeredagowuje zdania tak, by tworzyły spójną narrację bez zmiany sensu,
 - zwraca poprawiony tekst, który trafia do walidacji.
 

--- a/public/generuj.html
+++ b/public/generuj.html
@@ -89,6 +89,9 @@ function startStream() {
     if (msg.log) {
       appendLog(msg.log);
     }
+  if (msg.error) {
+    appendLog(`❌ Błąd: ${msg.error}`);
+  }
   if (msg.warnings) {
     appendLog('⚠️ Ostrzeżenia:');
     const list = document.createElement('ul');
@@ -160,12 +163,20 @@ function startStream() {
     continueBtn.style.display = 'inline-block';
   }
   if (msg.prompt) {
-    appendLog('📝 Prompt:');
-    appendLog(msg.prompt);
+    appendLog('📝 Kontekst wysłany do OpenAI:');
+    appendLog(
+      typeof msg.prompt === 'string'
+        ? msg.prompt
+        : JSON.stringify(msg.prompt, null, 2),
+    );
   }
   if (msg.response) {
     appendLog('💬 Odpowiedź:');
     appendLog(msg.response);
+  }
+  if (msg.debug) {
+    appendLog('🐞 Debug:');
+    appendLog(typeof msg.debug === 'string' ? msg.debug : JSON.stringify(msg.debug, null, 2));
   }
   if (msg.heroPrompt) {
     appendLog('🎨 Prompt (obrazek):');
@@ -181,7 +192,7 @@ function startStream() {
   };
   es.onerror = (err) => {
     statusEl.textContent = 'Błąd połączenia (SSE)';
-    appendLog('❌ Błąd połączenia (SSE)');
+    appendLog(`❌ Błąd połączenia (SSE): ${err?.message || err}`);
     console.error('EventSource failed', err);
     sendLog('sse-error', { message: err.message });
     es.close();

--- a/src/modules/generateAndPublish.ts
+++ b/src/modules/generateAndPublish.ts
@@ -57,6 +57,7 @@ export async function generateAndPublish(
 
     if (promptPromise) {
       send('suggest-topic-start');
+      send('🧠 Generuję propozycje tematów przy użyciu OpenAI...');
       let sugRes;
       try {
         sugRes = await suggestArticleTopic(
@@ -64,13 +65,14 @@ export async function generateAndPublish(
           recent,
           env.OPENAI_API_KEY,
         );
-        send('suggest-topic-prompt', { prompt: sugRes.prompt });
+        send('suggest-topic-prompt', { prompt: sugRes.messages });
         send('suggest-topic-response', { response: sugRes.raw });
       } catch (err) {
         send('suggest-topic-error', {
           error: (err as Error).message,
-          prompt: (err as any).prompt,
+          prompt: (err as any).messages,
           response: (err as any).raw,
+          debug: (err as any).debug,
         });
         throw err;
       }
@@ -92,12 +94,12 @@ export async function generateAndPublish(
         baseTopic,
         model: env.OPENAI_TEXT_MODEL || 'gpt-5',
       });
-      send('outline-prompt', { prompt: outlineRes.prompt });
+      send('outline-prompt', { prompt: outlineRes.messages });
       send('outline-response', { response: outlineRes.raw });
     } catch (err) {
       send('outline-error', {
         error: (err as Error).message,
-        prompt: (err as any).prompt,
+        prompt: (err as any).messages,
         response: (err as any).raw,
       });
       throw err;
@@ -115,12 +117,12 @@ export async function generateAndPublish(
         model: env.OPENAI_TEXT_MODEL || 'gpt-5',
         maxTokens: 7200,
       });
-      send('draft-prompt', { prompt: draftRes.prompt });
+      send('draft-prompt', { prompt: draftRes.messages });
       send('draft-response', { response: draftRes.raw });
     } catch (err) {
       send('draft-error', {
         error: (err as Error).message,
-        prompt: (err as any).prompt,
+        prompt: (err as any).messages,
         response: (err as any).raw,
       });
       throw err;
@@ -138,12 +140,12 @@ export async function generateAndPublish(
         model: env.OPENAI_TEXT_MODEL || 'gpt-5',
         maxTokens: 7200,
       });
-      send('edit-prompt', { prompt: editRes.prompt });
+      send('edit-prompt', { prompt: editRes.messages });
       send('edit-response', { response: editRes.raw });
     } catch (err) {
       send('edit-error', {
         error: (err as Error).message,
-        prompt: (err as any).prompt,
+        prompt: (err as any).messages,
         response: (err as any).raw,
       });
       throw err;
@@ -160,12 +162,12 @@ export async function generateAndPublish(
         model: env.OPENAI_TEXT_MODEL || 'gpt-5',
         maxTokens: 7200,
       });
-      send('proofread-prompt', { prompt: proofRes.prompt });
+      send('proofread-prompt', { prompt: proofRes.messages });
       send('proofread-response', { response: proofRes.raw });
     } catch (err) {
       send('proofread-error', {
         error: (err as Error).message,
-        prompt: (err as any).prompt,
+        prompt: (err as any).messages,
         response: (err as any).raw,
       });
       throw err;

--- a/src/modules/topicSuggester.test.ts
+++ b/src/modules/topicSuggester.test.ts
@@ -18,11 +18,13 @@ test('suggestArticleTopic avoids recent titles and covers multiple themes', asyn
         choices: [
           {
             message: {
-              content: JSON.stringify([
-                { title: 'Nowy tytuł 1', rationale: 'Polityka: satyryczny komentarz' },
-                { title: 'Nowy tytuł 2', rationale: 'Ekologia: ironiczny ton' },
-                { title: 'Nowy tytuł 3', rationale: 'Historia: patriotyczna nuta' },
-              ]),
+              parsed: {
+                results: [
+                  { title: 'Nowy tytuł 1', rationale: 'Polityka: satyryczny komentarz' },
+                  { title: 'Nowy tytuł 2', rationale: 'Ekologia: ironiczny ton' },
+                  { title: 'Nowy tytuł 3', rationale: 'Historia: patriotyczna nuta' },
+                ],
+              },
             },
           },
         ],
@@ -42,7 +44,9 @@ test('suggestArticleTopic avoids recent titles and covers multiple themes', asyn
   }
   const themes = new Set(res.suggestions.map(s => s.rationale.split(':')[0]));
   assert.ok(themes.size >= 2);
-  assert.ok(res.prompt.includes('Mam listę gorących tematów'));
+  assert.ok(
+    res.messages.some(m => m.role === 'user' && m.content.includes('Mam listę gorących tematów')),
+  );
   assert.ok(res.raw.length > 0);
 
   globalThis.fetch = originalFetch;

--- a/src/pipeline/edit.ts
+++ b/src/pipeline/edit.ts
@@ -2,7 +2,7 @@ import { logEvent, logError } from '../utils/logger';
 import { buildEditPrompt } from './prompts';
 import { scrubTodoClaims } from './scrubTodoClaims';
 import type { Outline, Draft, Edited } from './types';
-import { chat } from './openai';
+import { chat, type ChatMessage } from './openai';
 import { guardrails } from './guardrails';
 import { extractJson } from '../utils/json';
 
@@ -16,20 +16,24 @@ export interface EditDraftOptions {
 
 export interface EditDraftResult {
   edited: Edited;
-  prompt: string;
+  messages: ChatMessage[];
   raw: string;
 }
 
 export async function editDraft({ apiKey, draft, outline, model = 'gpt-5', maxTokens }: EditDraftOptions): Promise<EditDraftResult> {
-  const prompt = buildEditPrompt(draft, outline);
+  const userPrompt = buildEditPrompt(draft, outline);
   logEvent({ type: 'edit-start' });
+  const messages: ChatMessage[] = [
+    { role: 'system', content: guardrails() },
+    { role: 'user', content: userPrompt },
+  ];
   let text = '';
   try {
     text = await chat(apiKey, {
-      system: guardrails(),
-      user: prompt,
+      messages,
       max_completion_tokens: maxTokens ?? 1000,
       model,
+      response_style: 'full',
     });
     const json: Edited = extractJson<Edited>(text);
     if (json.title.length > 100 || json.description.length > 200) {
@@ -44,10 +48,11 @@ export async function editDraft({ apiKey, draft, outline, model = 'gpt-5', maxTo
     }
     const result: Edited = { ...json, markdown: cleaned };
     logEvent({ type: 'edit-complete', title: result.title });
-    return { edited: result, prompt, raw: text };
+    return { edited: result, messages, raw: text };
   } catch (err) {
     logError(err, { type: 'edit-error', raw: text });
-    (err as any).prompt = prompt;
+    (err as any).prompt = userPrompt;
+    (err as any).messages = messages;
     (err as any).raw = text;
     throw err;
   }

--- a/src/pipeline/openai.ts
+++ b/src/pipeline/openai.ts
@@ -1,61 +1,126 @@
 import { logEvent, logError } from '../utils/logger';
 import { retryFetch } from '../utils/retryFetch';
 
+export interface ChatMessage {
+  role: string;
+  content: string;
+}
+
 export interface ChatOptions {
-  system?: string;
-  user: string;
+  messages: ChatMessage[];
   max_completion_tokens: number;
   model?: string;
   response_format?: Record<string, unknown>;
+  response_style?: 'brief' | 'normal' | 'full';
 }
 
-export async function chat(apiKey: string, {
-  system,
-  user,
-  max_completion_tokens,
-  model = 'gpt-5',
-  response_format,
-}: ChatOptions): Promise<string> {
-  const messages: any[] = [];
-  if (system) messages.push({ role: 'system', content: system });
-  messages.push({ role: 'user', content: user });
-
-  logEvent({ type: 'openai-request', model, promptSnippet: user.slice(0, 100) });
-  try {
-    const body: Record<string, unknown> = {
-      model,
-      max_completion_tokens,
-      messages,
-    };
-    if (response_format) body.response_format = response_format;
-    const res = await retryFetch('https://api.openai.com/v1/chat/completions', {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${apiKey}`,
-      },
-      body: JSON.stringify(body),
-      retries: 2,
-      retryDelayMs: 1000,
-    });
-    logEvent({ type: 'openai-response-status', status: res.status });
-    if (!res.ok) {
-      const msg = await res.text();
-      throw new Error(`OpenAI request failed: ${res.status} ${msg}`);
+export async function chat(
+  apiKey: string,
+  {
+    messages,
+    max_completion_tokens,
+    model = 'gpt-5',
+    response_format,
+    response_style,
+  }: ChatOptions,
+): Promise<string> {
+  let finalMessages = messages;
+  if (response_style) {
+    const styleMsg = { role: 'system', content: `response_style:${response_style}` };
+    if (messages.length && messages[0].role === 'system') {
+      finalMessages = [messages[0], styleMsg, ...messages.slice(1)];
+    } else {
+      finalMessages = [styleMsg, ...messages];
     }
-    const data: any = await res.json();
-    logEvent({ type: 'openai-response-received' });
-    if (!data.choices || !data.choices[0]) {
-      throw new Error('OpenAI response missing choices');
-    }
-    const text = (data.choices[0].message.content || '').trim();
-    logEvent({ type: 'openai-response-text', text });
-    if (!text) {
-      throw new Error('OpenAI response empty');
-    }
-    return text;
-  } catch (err) {
-    logError(err, { type: 'openai-error' });
-    throw err;
   }
+
+  let tokens = max_completion_tokens;
+  for (let attempt = 0; attempt < 2; attempt++) {
+    const userMsg = finalMessages.findLast?.(m => m.role === 'user') || finalMessages[finalMessages.length - 1];
+    logEvent({
+      type: 'openai-request',
+      model,
+      messages: finalMessages,
+      response_style,
+      max_tokens: tokens,
+      attempt,
+      promptSnippet: userMsg?.content?.slice(0, 100) || '',
+    });
+    try {
+      const body: Record<string, unknown> = {
+        model,
+        max_completion_tokens: tokens,
+        messages: finalMessages,
+      };
+      if (response_format) body.response_format = response_format;
+      const res = await retryFetch('https://api.openai.com/v1/chat/completions', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${apiKey}`,
+        },
+        body: JSON.stringify(body),
+        retries: 2,
+        retryDelayMs: 1000,
+      });
+      logEvent({ type: 'openai-response-status', status: res.status });
+      if (!res.ok) {
+        const msg = await res.text();
+        throw new Error(`OpenAI request failed: ${res.status} ${msg}`);
+      }
+      const data: any = await res.json();
+      logEvent({ type: 'openai-response-received' });
+      if (data.usage) {
+        logEvent({ type: 'openai-usage', usage: data.usage });
+      }
+      if (!data.choices || !data.choices[0]) {
+        throw new Error('OpenAI response missing choices');
+      }
+
+      const choice = data.choices[0];
+      const message = choice.message || {};
+      if (message.refusal) {
+        logEvent({ type: 'openai-response-refusal', refusal: message.refusal });
+        throw new Error(`OpenAI refusal: ${message.refusal}`);
+      }
+
+      let text = '';
+      const content = message.content;
+      if (Array.isArray(content)) {
+        text = content.map((c: any) => c.text || '').join('').trim();
+      } else if (typeof content === 'string') {
+        text = content.trim();
+      } else if (content && typeof content.text === 'string') {
+        text = content.text.trim();
+      } else if (message.parsed) {
+        try {
+          text = JSON.stringify(message.parsed).trim();
+        } catch {}
+      }
+
+      logEvent({ type: 'openai-response-text', text });
+      if (text) return text;
+
+      const finish = choice.finish_reason;
+      logEvent({
+        type: 'openai-response-debug',
+        message,
+        data,
+        finish_reason: finish,
+      });
+      if (finish === 'length' && attempt === 0) {
+        tokens *= 2;
+        logEvent({ type: 'openai-retry-length', next_max_tokens: tokens });
+        continue;
+      }
+
+      const err: any = new Error('OpenAI response empty');
+      err.debug = { message, data, finish_reason: finish };
+      throw err;
+    } catch (err) {
+      logError(err, { type: 'openai-error' });
+      throw err;
+    }
+  }
+  throw new Error('OpenAI response empty after retries');
 }

--- a/src/pipeline/outline.test.ts
+++ b/src/pipeline/outline.test.ts
@@ -74,7 +74,9 @@ test('generateOutline exposes prompt and raw on error', async () => {
       await generateOutline({ apiKey: 'k', baseTopic: 'T' });
     },
     (err: any) => {
-      assert.ok(err.prompt.includes('Temat bazowy: T'));
+      assert.ok(
+        err.messages.some((m: any) => m.role === 'user' && m.content.includes('Temat bazowy: T')),
+      );
       assert.equal(err.raw, '');
       return /No JSON/.test(err.message);
     }


### PR DESCRIPTION
## Summary
- Introduce response-style contract for OpenAI chats and log full message context
- Forward complete OpenAI request messages to the generator UI for easier debugging
- Document response_style usage across topic suggestion, outline, draft, edit and proofread steps
- Parse topic suggestions from OpenAI when wrapped in a `results` object and log the parsed payload
- Append `response_style` as a system message instead of a top-level request parameter to avoid OpenAI 400 errors

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689c5d3e97b4832ca4fe0f296ed0756a