### PR TITLE
Repair JSON parsing for OpenAI responses

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@astrojs/rss": "4.0.11",
         "@astrojs/sitemap": "3.2.1",
         "astro": "5.1.3",
+        "jsonrepair": "^3.13.1",
         "node-html-parser": "^7.0.1",
         "typescript": "5.7.2"
       },
@@ -4304,6 +4305,15 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsonrepair": {
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/jsonrepair/-/jsonrepair-3.13.1.tgz",
+      "integrity": "sha512-WJeiE0jGfxYmtLwBTEk8+y/mYcaleyLXWaqp5bJu0/ZTSeG0KQq/wWQ8pmnkKenEdN6pdnn6QtcoSUkbqDHWNw==",
+      "license": "ISC",
+      "bin": {
+        "jsonrepair": "bin/cli.js"
       }
     },
     "node_modules/kleur": {

--- a/package.json
+++ b/package.json
@@ -18,8 +18,9 @@
     "@astrojs/rss": "4.0.11",
     "@astrojs/sitemap": "3.2.1",
     "astro": "5.1.3",
-    "typescript": "5.7.2",
-    "node-html-parser": "^7.0.1"
+    "jsonrepair": "^3.13.1",
+    "node-html-parser": "^7.0.1",
+    "typescript": "5.7.2"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20250204.0",

--- a/src/utils/json.ts
+++ b/src/utils/json.ts
@@ -1,3 +1,5 @@
+import { jsonrepair } from 'jsonrepair';
+
 export function extractJson<T>(text: string): T {
   const original = text.trim();
   let jsonText = original;
@@ -34,6 +36,13 @@ export function extractJson<T>(text: string): T {
   try {
     return JSON.parse(jsonText);
   } catch (err) {
-    throw new Error(`Failed to parse JSON: ${(err as Error).message}. Input: ${jsonText}`);
+    try {
+      const repaired = jsonrepair(jsonText);
+      return JSON.parse(repaired);
+    } catch (repairErr) {
+      throw new Error(
+        `Failed to parse JSON: ${(repairErr as Error).message}. Original error: ${(err as Error).message}. Input: ${jsonText}`
+      );
+    }
   }
 }


### PR DESCRIPTION
## Summary
- add the jsonrepair dependency to post-process language model responses
- fall back to jsonrepair in extractJson so malformed JSON with stray quotes can be recovered before parsing

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ceb427bafc832c874c584c066d7480