### PR TITLE
Automate cron topic selection

### DIFF
--- a/docs/article-generation.md
+++ b/docs/article-generation.md
@@ -5,7 +5,7 @@ Ten projekt automatyzuje tworzenie satyrycznych wpisów na bloga. Poniżej opisa
 ## 1. Gorące tematy i wybór wątku
 1. Pobierz tytuły ostatnich artykułów z GitHuba.
 2. `getHotTopics()` zbiera wiadomości z RSS (BBC, Politico, PAP, Reuters). Lista jest wysyłana w logu SSE `🔥 Gorące tematy z ostatnich dni`.
-3. `suggestArticleTopic()` (max_completion_tokens 2000, `response_style=brief`) proponuje satyryczne tematy na podstawie gorących newsów i ostatnich wpisów. Użytkownik wybiera jedną z propozycji lub podaje własny temat bazowy.
+3. `suggestArticleTopic()` (max_completion_tokens 2000, `response_style=brief`) proponuje satyryczne tematy na podstawie gorących newsów i ostatnich wpisów. W trybie interaktywnym użytkownik wybiera jedną z propozycji lub podaje własny temat bazowy. Dla zadań wywołanych z crona Cloudflare Worker automatycznie wybiera pierwszą sugestię (lub wraca do najgorętszego tematu RSS przy błędzie), dzięki czemu publikacja przebiega bez udziału człowieka.
 
 ## 2. Outline
 `generateOutline(baseTopic)` przygotowuje strukturę artykułu:


### PR DESCRIPTION
## Summary
- ensure cron-triggered article generation automatically requests topic suggestions, selects the best available option, and records automation logs without waiting for user input
- document the cron automation behaviour in the article generation guide so the hands-off flow is clear

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cfb570f3f4832cba9ca4cfaccd497a