### PR TITLE
Retry OpenAI calls after empty responses

### DIFF
--- a/src/pipeline/openai.ts
+++ b/src/pipeline/openai.ts
@@ -140,6 +140,17 @@ export async function chat(
         }
       }
 
+      if (attempt < MAX_LENGTH_RETRIES - 1) {
+        logEvent({
+          type: 'openai-retry-empty',
+          attempt,
+          next_attempt: attempt + 1,
+          finish_reason: finish,
+        });
+        await new Promise(resolve => setTimeout(resolve, 300 * (attempt + 1)));
+        continue;
+      }
+
       const err: any = new Error('OpenAI response empty');
       err.debug = { message, data, finish_reason: finish };
       throw err;


### PR DESCRIPTION
## Summary
- add retry handling for empty message bodies returned from OpenAI chat completions
- wait briefly and log retry attempts before failing

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d26e45c598832ca8c8a01113ce550f