### PR TITLE
Handle OpenAI output_text fields in chat parser

### DIFF
--- a/src/pipeline/openai.ts
+++ b/src/pipeline/openai.ts
@@ -106,11 +106,30 @@ export async function chat(
       if (!text) {
         const content = message.content;
         if (Array.isArray(content)) {
-          text = content.map((c: any) => c.text || '').join('').trim();
+          text = content
+            .map((c: any) => {
+              if (!c) return '';
+              if (typeof c === 'string') return c;
+              if (typeof c.text === 'string') return c.text;
+              if (Array.isArray(c.output_text)) return c.output_text.join('');
+              if (typeof c.output_text === 'string') return c.output_text;
+              return '';
+            })
+            .join('')
+            .trim();
         } else if (typeof content === 'string') {
           text = content.trim();
         } else if (content && typeof content.text === 'string') {
           text = content.text.trim();
+        }
+      }
+
+      if (!text) {
+        const outputText = (message as any).output_text;
+        if (Array.isArray(outputText)) {
+          text = outputText.join('').trim();
+        } else if (typeof outputText === 'string') {
+          text = outputText.trim();
         }
       }
 


### PR DESCRIPTION
## Summary
- broaden chat response parsing to extract text from output_text arrays and strings returned by the OpenAI API
- ensure the proofread stage can recover usable content even when the response_content array lacks plain text entries

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68da7bcd176c832cb2aa04aad78c5adc